### PR TITLE
Properties for getting 'position', 'direction' and 'up' vectors and 'fov' fix

### DIFF
--- a/collada/camera.py
+++ b/collada/camera.py
@@ -95,7 +95,7 @@ class Camera(DaeObject):
             correction = float(correction)
         except ValueError, ex: 
             raise DaeMalformedError('Corrupted float values in camera definition')
-        fov *= correction
+        fov /= correction
         znearnode = persnode.find( tag('znear') )
         zfarnode = persnode.find( tag('zfar') )
         try: 


### PR DESCRIPTION
Hi there, I reckon it might be useful to have accessors for the basic properties of the camera (and in the future, perhaps lights as well?). Does this jive with the design of PyCollada?

I didn't normalize these vectors because I reckon that the transformation matrix is already orthogonal. Is this ok?

I also fixed a bug where the field of view of the camera is corrected by the aspect ratio when it is specified as xfov.
This correction was being multiplied, but in the case of the xfov it should be divided because aspect ratio is defined as xfov/yfov in COLLADA. (Hence xfov / (xfov/yfov) gives yfov). Could I suggest that this code might be simplified a little bit? I don't think it's necessary to use the correction at all when yfov is given since yfov is already correct, I think this might be the source of the confusion.
