### PR TITLE
Python 3k compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.swp
 .project
 .pydevproject
 docs/_build

--- a/collada/__init__.py
+++ b/collada/__init__.py
@@ -18,98 +18,28 @@ file is not what is expected.
 
 """
 
-from lxml import etree as ElementTree
-from lxml.builder import ElementMaker
-import zipfile
-from StringIO import StringIO
-import types
-import traceback
-from datetime import datetime
-import posixpath
 import os.path
+import posixpath
+import traceback
+import types
+import zipfile
+from datetime import datetime
+from lxml import etree as ElementTree
 
+from collada import animation
+from collada import asset
+from collada import camera
+from collada import controller
+from collada import geometry
+from collada import light
+from collada import material
+from collada import scene
+from collada import schema
+from collada.common import E, tag
+from collada.common import DaeError
+from collada.util import IndexedList
+from collada.util import basestring, BytesIO
 
-E = ElementMaker(namespace='http://www.collada.org/2005/11/COLLADASchema',
-                 nsmap={None: 'http://www.collada.org/2005/11/COLLADASchema'})
-def tag( text ):
-    return str(ElementTree.QName( 'http://www.collada.org/2005/11/COLLADASchema', text ))
-
-class DaeObject(object):
-    """This class is the abstract interface to all collada objects.
-
-    Every <tag> in a COLLADA that we recognize and load has mirror
-    class deriving from this one. All instances will have at least
-    a :meth:`load` method which creates the object from an xml node and
-    an attribute called :attr:`xmlnode` with the ElementTree representation
-    of the data. Even if it was created on the fly. If the object is
-    not read-only, it will also have a :meth:`save` method which saves the
-    object's information back to the :attr:`xmlnode` attribute.
-
-    """
-
-    xmlnode = None
-    """ElementTree representation of the data."""
-
-    @staticmethod
-    def load(collada, localscope, node):
-        """Load and return a class instance from an XML node.
-
-        Inspect the data inside node, which must match
-        this class tag and create an instance out of it.
-
-        :param collada.Collada collada:
-          The collada file object where this object lives
-        :param dict localscope:
-          If there is a local scope where we should look for local ids 
-          (sid) this is the dictionary. Otherwise empty dict ({})
-        :param node:
-          An Element from python's ElementTree API
-
-        """
-        raise Exception('Not implemented')
-
-    def save(self):
-        """Put all the data to the internal xml node (xmlnode) so it can be serialized."""
-
-class DaeError(Exception):
-    """General DAE exception."""
-    def __init__(self, msg):
-        super(DaeError,self).__init__()
-        self.msg = msg
-
-    def __str__(self): return type(self).__name__ + ': ' + self.msg
-    def __repr__(self): return type(self).__name__ + '("' + self.msg + '")'
-
-class DaeIncompleteError(DaeError):
-    """Raised when needed data for an object isn't there."""
-    pass
-
-class DaeBrokenRefError(DaeError):
-    """Raised when a referenced object is not found in the scope."""
-    pass
-
-class DaeMalformedError(DaeError):
-    """Raised when data is found to be corrupted in some way."""
-    pass
-
-class DaeUnsupportedError(DaeError):
-    """Raised when some unexpectedly unsupported feature is found."""
-    pass
-
-class DaeSaveValidationError(DaeError):
-    """Raised when XML validation fails when saving."""
-    pass
-
-import geometry
-import scene
-import material
-import camera
-import light
-import controller
-import animation
-import asset
-import schema
-from util import IndexedList
 
 class Collada(object):
     """This is the main class used to create and load collada documents"""
@@ -137,7 +67,7 @@ class Collada(object):
 
     def __init__(self, filename=None, ignore=None, aux_file_loader=None, zip_filename=None, validate_output=False):
         """Load collada data from filename or file like object.
-        
+
         :param filename:
           String containing path to filename to open or file-like object.
           Uncompressed .dae files are supported, as well as zip file archives.
@@ -164,12 +94,12 @@ class Collada(object):
           validated against the COLLADA 1.4.1 schema. If validation fails, the
           :class:`collada.DaeSaveValidationError` exception will be thrown.
         """
-        
+
         self.errors = []
         """List of :class:`collada.DaeError` objects representing errors encounterd while loading collada file"""
         self.assetInfo = None
         """Instance of :class:`collada.asset.Asset` containing asset information"""
-        
+
         self._geometries = IndexedList([], ('id',))
         self._controllers = IndexedList([], ('id',))
         self._animations = IndexedList([], ('id',))
@@ -180,24 +110,24 @@ class Collada(object):
         self._materials = IndexedList([], ('id',))
         self._nodes = IndexedList([], ('id',))
         self._scenes = IndexedList([], ('id',))
-        
+
         self.scene = None
         """The default scene. This is either an instance of :class:`collada.scene.Scene` or `None`."""
-        
+
         if validate_output:
             self.validator = schema.ColladaValidator()
         else:
             self.validator = None
-            
+
         self.maskedErrors = []
         if ignore is not None:
             self.ignoreErrors( *ignore )
-        
+
         if filename is None:
             self.filename = None
             self.zfile = None
             self.getFileData = aux_file_loader
-            
+
             self.xmlnode = ElementTree.ElementTree(
                                E.COLLADA(
                                    E.library_cameras(),
@@ -212,13 +142,11 @@ class Collada(object):
                                    E.scene(),
                                version='1.4.1'))
             """ElementTree representation of the collada document"""
-            
+
             self.assetInfo = asset.Asset()
-            
             return
-            
-        
-        if type(filename) in [types.StringType, types.UnicodeType]:
+
+        if isinstance(filename, basestring):
             fdata = open(filename, 'rb')
             self.filename = filename
             self.getFileData = self._getFileFromDisk
@@ -227,12 +155,12 @@ class Collada(object):
             self.filename = None
             self.getFileData = self._nullGetFile
         strdata = fdata.read()
-        
+
         try:
-            self.zfile = zipfile.ZipFile(StringIO(strdata), 'r')
+            self.zfile = zipfile.ZipFile(BytesIO(strdata), 'r')
         except:
             self.zfile = None
-        
+
         if self.zfile:
             self.filename = ''
             daefiles = []
@@ -253,16 +181,18 @@ class Collada(object):
             self.getFileData = self._getFileFromZip
         else:
             data = strdata
-        
+
         if aux_file_loader is not None:
             self.getFileData = aux_file_loader
-        
-        etree_parser = ElementTree.XMLParser(remove_comments=True, remove_blank_text=True)
+
+        etree_parser = ElementTree.XMLParser(remove_comments=True,
+                remove_blank_text=True)
         try:
-            self.xmlnode = ElementTree.ElementTree(element=None, file=StringIO(data), parser=etree_parser)
-        except ElementTree.XMLSyntaxError, e:
+            self.xmlnode = ElementTree.ElementTree(element=None,
+                    file=BytesIO(data), parser=etree_parser)
+        except ElementTree.XMLSyntaxError as e:
             raise DaeMalformedError("XML Syntax Parsing Error: %s" % e)
-        
+
         self._loadAssetInfo()
         self._loadImages()
         self._loadEffects()
@@ -296,7 +226,7 @@ class Collada(object):
             self.maskedErrors = []
         else:
             for e in args: self.maskedErrors.append(e)
-    
+
     def _getFileFromZip(self, fname):
         """Return the binary data of an auxiliary file from a zip archive as a string."""
         if not self.zfile:
@@ -304,7 +234,7 @@ class Collada(object):
         basepath = posixpath.dirname(self.filename)
         aux_path = posixpath.normpath(posixpath.join(basepath, fname))
         if aux_path not in self.zfile.namelist():
-            raise DaeBrokenRefError('Auxiliar file %s not found in archive'%fname)
+            raise DaeBrokenRefError('Auxiliar file %s not found in archive' % fname)
         return self.zfile.read( aux_path )
 
     def _getFileFromDisk(self, fname):
@@ -317,144 +247,166 @@ class Collada(object):
             raise DaeBrokenRefError('Auxiliar file %s not found on disk'%fname)
         fdata = open(aux_path, 'rb')
         return fdata.read()
-    
+
     def _nullGetFile(self, fname):
         raise DaeBrokenRefError('Trying to load auxiliary file but collada was not loaded from disk, zip, or with custom handler')
 
     def _loadAssetInfo(self):
         """Load information in <asset> tag"""
-        assetnode = self.xmlnode.find( tag('asset') )
+        assetnode = self.xmlnode.find(tag('asset'))
         if assetnode is not None:
             self.assetInfo = asset.Asset.load(self, {}, assetnode)
         else:
             self.assetInfo = asset.Asset()
-                    
+
     def _loadGeometry(self):
         """Load geometry library."""
-        libnodes = self.xmlnode.findall( tag('library_geometries') )
+        libnodes = self.xmlnode.findall(tag('library_geometries'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     for geomnode in libnode.findall(tag('geometry')):
-                        if geomnode.find(tag('mesh')) is None: continue
-                        try: G = geometry.Geometry.load( self, {}, geomnode )
-                        except DaeError, ex: self.handleError(ex)
+                        if geomnode.find(tag('mesh')) is None:
+                            continue
+                        try:
+                            G = geometry.Geometry.load(self, {}, geomnode)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
-                            self.geometries.append( G )
-    
+                            self.geometries.append(G)
+
     def _loadControllers(self):
         """Load controller library."""
-        libnodes = self.xmlnode.findall( tag('library_controllers') )
+        libnodes = self.xmlnode.findall(tag('library_controllers'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     for controlnode in libnode.findall(tag('controller')):
-                        if controlnode.find(tag('skin')) is None and controlnode.find(tag('morph')) is None:
+                        if controlnode.find(tag('skin')) is None \
+                                and controlnode.find(tag('morph')) is None:
                             continue
-                        try: C = controller.Controller.load( self, {}, controlnode )
-                        except DaeError, ex: self.handleError(ex)
+                        try:
+                            C = controller.Controller.load(self, {}, controlnode)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
-                            self.controllers.append( C )
-    
+                            self.controllers.append(C)
+
     def _loadAnimations(self):
         """Load animation library."""
-        libnodes = self.xmlnode.findall( tag('library_animations') )
+        libnodes = self.xmlnode.findall(tag('library_animations'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     for animnode in libnode.findall(tag('animation')):
-                        try: A = animation.Animation.load( self, {}, animnode )
-                        except DaeError, ex: self.handleError(ex)
+                        try:
+                            A = animation.Animation.load(self, {}, animnode)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
-                            self.animations.append( A )
-    
+                            self.animations.append(A)
+
     def _loadLights(self):
         """Load light library."""
-        libnodes = self.xmlnode.findall( tag('library_lights') )
+        libnodes = self.xmlnode.findall(tag('library_lights'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     for lightnode in libnode.findall(tag('light')):
-                        try: lig = light.Light.load( self, {}, lightnode )
-                        except DaeError, ex: self.handleError(ex)
+                        try:
+                            lig = light.Light.load(self, {}, lightnode)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
-                            self.lights.append( lig )
+                            self.lights.append(lig)
 
     def _loadCameras(self):
         """Load camera library."""
-        libnodes = self.xmlnode.findall( tag('library_cameras') )
+        libnodes = self.xmlnode.findall(tag('library_cameras'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     for cameranode in libnode.findall(tag('camera')):
-                        try: cam = camera.Camera.load( self, {}, cameranode )
-                        except DaeError, ex: self.handleError(ex)
+                        try:
+                            cam = camera.Camera.load(self, {}, cameranode)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
-                            self.cameras.append( cam )
+                            self.cameras.append(cam)
 
     def _loadImages(self):
         """Load image library."""
-        libnodes = self.xmlnode.findall( tag('library_images') )
+        libnodes = self.xmlnode.findall(tag('library_images'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     for imgnode in libnode.findall(tag('image')):
-                        try: img = material.CImage.load( self, {}, imgnode )
-                        except DaeError, ex: self.handleError(ex)
+                        try:
+                            img = material.CImage.load(self, {}, imgnode)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
-                            self.images.append( img )
+                            self.images.append(img)
 
     def _loadEffects(self):
         """Load effect library."""
-        libnodes = self.xmlnode.findall( tag('library_effects') )
+        libnodes = self.xmlnode.findall(tag('library_effects'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     for effectnode in libnode.findall(tag('effect')):
-                        try: effect = material.Effect.load( self, {}, effectnode )
-                        except DaeError, ex: self.handleError(ex)
+                        try:
+                            effect = material.Effect.load(self, {}, effectnode)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
-                            self.effects.append( effect )
+                            self.effects.append(effect)
 
     def _loadMaterials(self):
         """Load material library."""
-        libnodes = self.xmlnode.findall( tag('library_materials'))
+        libnodes = self.xmlnode.findall(tag('library_materials'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     for materialnode in libnode.findall(tag('material')):
-                        try: mat = material.Material.load( self, {}, materialnode )
-                        except DaeError, ex: self.handleError(ex)
+                        try:
+                            mat = material.Material.load(self, {}, materialnode)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
-                            self.materials.append( mat )
+                            self.materials.append(mat)
 
     def _loadNodes(self):
-        libnodes = self.xmlnode.findall( tag('library_nodes') )
+        libnodes = self.xmlnode.findall(tag('library_nodes'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     tried_loading = []
                     succeeded = False
                     for node in libnode.findall(tag('node')):
-                        try: N = scene.loadNode(self, node, {})
-                        except scene.DaeInstanceNotLoadedError, ex:
+                        try:
+                            N = scene.loadNode(self, node, {})
+                        except scene.DaeInstanceNotLoadedError as ex:
                             tried_loading.append((node, ex))
-                        except DaeError, ex: self.handleError(ex)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
                             if N is not None:
-                                self.nodes.append( N )
+                                self.nodes.append(N)
                                 succeeded = True
                     while len(tried_loading) > 0 and succeeded:
                         succeeded = False
                         next_tried = []
                         for node, ex in tried_loading:
-                            try: N = scene.loadNode(self, node, {})
-                            except scene.DaeInstanceNotLoadedError, ex:
+                            try:
+                                N = scene.loadNode(self, node, {})
+                            except scene.DaeInstanceNotLoadedError as ex:
                                 next_tried.append((node, ex))
-                            except DaeError, ex: self.handleError(ex)
+                            except DaeError as ex:
+                                self.handleError(ex)
                             else:
                                 if N is not None:
-                                    self.nodes.append( N )
+                                    self.nodes.append(N)
                                     succeeded = True
                         tried_loading = next_tried
                     if len(tried_loading) > 0:
@@ -463,19 +415,21 @@ class Collada(object):
 
     def _loadScenes(self):
         """Load scene library."""
-        libnodes = self.xmlnode.findall( tag('library_visual_scenes') )
+        libnodes = self.xmlnode.findall(tag('library_visual_scenes'))
         if libnodes is not None:
             for libnode in libnodes:
                 if libnode is not None:
                     for scenenode in libnode.findall(tag('visual_scene')):
-                        try: S = scene.Scene.load( self, scenenode )
-                        except DaeError, ex: self.handleError(ex)
+                        try:
+                            S = scene.Scene.load(self, scenenode)
+                        except DaeError as ex:
+                            self.handleError(ex)
                         else:
-                            self.scenes.append( S )
+                            self.scenes.append(S)
 
     def _loadDefaultScene(self):
         """Loads the default scene from <scene> tag in the root node."""
-        node = self.xmlnode.find('%s/%s'%( tag('scene'), tag('instance_visual_scene') ) )
+        node = self.xmlnode.find('%s/%s' % (tag('scene'), tag('instance_visual_scene')))
         try:
             if node != None:
                 sceneid = node.get('url')
@@ -483,8 +437,9 @@ class Collada(object):
                     raise DaeMalformedError('Malformed default scene reference to %s: '%sceneid)
                 self.scene = self.scenes.get(sceneid[1:])
                 if not self.scene:
-                    raise DaeBrokenRefError('Default scene %s not found'%sceneid)
-        except DaeError, ex: self.handleError(ex)
+                    raise DaeBrokenRefError('Default scene %s not found' % sceneid)
+        except DaeError as ex:
+            self.handleError(ex)
 
     def save(self):
         """Saves the collada document back to :attr:`xmlnode`"""
@@ -497,19 +452,19 @@ class Collada(object):
                      (self.materials, 'library_materials'),
                      (self.nodes, 'library_nodes'),
                      (self.scenes, 'library_visual_scenes')]
-        
+
         self.assetInfo.save()
-        assetnode = self.xmlnode.getroot().find( tag('asset') )
+        assetnode = self.xmlnode.getroot().find(tag('asset'))
         if assetnode is not None:
             self.xmlnode.getroot().replace(assetnode, self.assetInfo.xmlnode)
         else:
             self.xmlnode.getroot().insert(0, self.assetInfo.xmlnode)
-        
+
         library_loc = 0
         for i, node in enumerate(self.xmlnode.getroot()):
             if node.tag == tag('asset'):
                 library_loc = i+1
-        
+
         for arr, name in libraries:
             node = self.xmlnode.find( tag(name) )
             if node is None:
@@ -520,7 +475,7 @@ class Collada(object):
             elif node is not None and len(arr) == 0:
                 self.xmlnode.getroot().remove(node)
                 continue
-            
+
             for o in arr:
                 o.save()
                 if o.xmlnode not in node:
@@ -530,36 +485,36 @@ class Collada(object):
                 if n not in xmlnodes:
                     node.remove(n)
 
-        scenenode = self.xmlnode.find( tag('scene') )
+        scenenode = self.xmlnode.find(tag('scene'))
         scenenode.clear()
         if self.scene is not None:
             sceneid = self.scene.id
             if sceneid not in self.scenes:
-                raise DaeBrokenRefError('Default scene %s not found'%sceneid)
-            scenenode.append(E.instance_visual_scene(url="#%s"%sceneid))
-            
+                raise DaeBrokenRefError('Default scene %s not found' % sceneid)
+            scenenode.append(E.instance_visual_scene(url="#%s" % sceneid))
+
         if self.validator is not None:
             if not self.validator.validate(self.xmlnode):
-                raise DaeSaveValidationError("Validation error when saving: " + 
-                                             schema.COLLADA_SCHEMA_1_4_1_INSTANCE.error_log.last_error.message)
+                raise DaeSaveValidationError("Validation error when saving: " +
+                        schema.COLLADA_SCHEMA_1_4_1_INSTANCE.error_log.last_error.message)
 
-    def write(self, file):
+    def write(self, fp):
         """Writes out the collada document to a file. Note that this also
         calls :meth:`save` so avoid calling both methods to save performance.
-        
+
         :param file:
           Either the file name to write to or a file-like object
-        
-        """
-        
-        self.save()
-        if type(file) in [types.StringType, types.UnicodeType]:
-            f = open(file, 'w')
-        else:
-            f = file
-            
-        self.xmlnode.write(f, pretty_print=True)
 
-    def __str__(self): return '<Collada geometries=%d>' % (len(self.geometries))
-    def __repr__(self): return str(self)
-    
+        """
+
+        self.save()
+        if isinstance(fp, basestring):
+            fp = open(fp, 'wb')
+        self.xmlnode.write(fp, pretty_print=True)
+
+    def __str__(self):
+        return '<Collada geometries=%d>' % (len(self.geometries))
+
+    def __repr__(self):
+        return str(self)
+

--- a/collada/__main__.py
+++ b/collada/__main__.py
@@ -10,8 +10,12 @@
 #                                                                  #
 ####################################################################
 
-import unittest2
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from collada.util import unittest
 
 if __name__ == '__main__':
-    suite = unittest2.TestLoader().discover("tests")
-    unittest2.TextTestRunner(verbosity=2).run(suite)
+    suite = unittest.TestLoader().discover("tests")
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/collada/animation.py
+++ b/collada/animation.py
@@ -12,9 +12,10 @@
 
 """Contains objects representing animations."""
 
-from collada import DaeObject, DaeIncompleteError, DaeBrokenRefError, \
-                    DaeMalformedError, DaeUnsupportedError, tag
-import source
+from collada import source
+from collada.common import DaeObject, tag
+from collada.common import DaeIncompleteError, DaeBrokenRefError, \
+        DaeMalformedError, DaeUnsupportedError
 
 class Animation(DaeObject):
     """Class for holding animation data coming from <animation> tags."""
@@ -32,7 +33,7 @@ class Animation(DaeObject):
     def load( collada, localscope, node ):
         id = node.get('id') or ''
         name = node.get('name') or ''
-        
+
         sourcebyid = localscope
         sources = []
         sourcenodes = node.findall(tag('source'))
@@ -40,15 +41,16 @@ class Animation(DaeObject):
             ch = source.Source.load(collada, {}, sourcenode)
             sources.append(ch)
             sourcebyid[ch.id] = ch
-        
+
         child_nodes = node.findall(tag('animation'))
         children = []
         for child in child_nodes:
             try:
                 child = Animation.load(collada, sourcebyid, child)
                 children.append(child)
-            except DaeError, ex: collada.handleError(ex)
-        
+            except DaeError as ex:
+                collada.handleError(ex)
+
         anim = Animation(id, name, sourcebyid, children, node)
         return anim
 

--- a/collada/asset.py
+++ b/collada/asset.py
@@ -12,13 +12,16 @@
 
 """Contains COLLADA asset information."""
 
-from lxml import etree as ElementTree
 import numpy
-from collada import DaeObject, DaeIncompleteError, DaeBrokenRefError, \
-                    DaeMalformedError, DaeUnsupportedError, tag, E
-from collada.util import _correctValInNode
-import dateutil.parser
 import datetime
+import dateutil.parser
+from lxml import etree as ElementTree
+
+from collada.common import DaeObject, E, tag
+from collada.common import DaeIncompleteError, DaeBrokenRefError, \
+        DaeMalformedError, DaeUnsupportedError
+from collada.util import _correctValInNode
+
 
 class UP_AXIS:
     """The up-axis of the collada document."""
@@ -28,13 +31,13 @@ class UP_AXIS:
     """Indicates Y direction is up"""
     Z_UP = 'Z_UP'
     """Indicates Z direction is up"""
-    
+
 class Contributor(DaeObject):
     """Defines authoring information for asset management"""
-    
+
     def __init__(self, author=None, authoring_tool=None, comments=None, copyright=None, source_data=None, xmlnode=None):
         """Create a new contributor
-        
+
         :param str author:
           The author's name
         :param str authoring_tool:
@@ -47,7 +50,7 @@ class Contributor(DaeObject):
           URI referencing the source data
         :param xmlnode:
           If loaded from xml, the xml node
-        
+
         """
         self.author = author
         """Contains a string with the author's name."""
@@ -59,7 +62,7 @@ class Contributor(DaeObject):
         """Contains a string with copyright information."""
         self.source_data = source_data
         """Contains a string with a URI referencing the source data for this asset."""
-        
+
         if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the contributor."""
@@ -75,7 +78,7 @@ class Contributor(DaeObject):
                 self.xmlnode.append(E.copyright(str(copyright)))
             if source_data is not None:
                 self.xmlnode.append(E.source_data(str(source_data)))
-    
+
     @staticmethod
     def load(collada, localscope, node):
         author = node.find( tag('author') )
@@ -98,17 +101,17 @@ class Contributor(DaeObject):
         _correctValInNode(self.xmlnode, 'comments', self.comments)
         _correctValInNode(self.xmlnode, 'copyright', self.copyright)
         _correctValInNode(self.xmlnode, 'source_data', self.source_data)
-        
+
     def __str__(self): return '<Contributor author=%s>' % (str(self.author),)
     def __repr__(self): return str(self)
-        
+
 class Asset(DaeObject):
     """Defines asset-management information"""
-    
+
     def __init__(self, created=None, modified=None, title=None, subject=None, revision=None,
                keywords=None, unitname=None, unitmeter=None, upaxis=None, contributors=None, xmlnode=None):
         """Create a new set of information about an asset
-        
+
         :param datetime.datetime created:
           When the asset was created. If None, this will be set to the current date and time.
         :param datetime.datetime modified:
@@ -131,19 +134,19 @@ class Asset(DaeObject):
           The list of contributors for the asset
         :param xmlnode:
           If loaded from xml, the xml node
-        
+
         """
-        
+
         if created is None:
             created = datetime.datetime.now()
         self.created = created
         """Instance of :class:`datetime.datetime` indicating when the asset was created"""
-        
+
         if modified is None:
             modified = datetime.datetime.now()
         self.modified = modified
         """Instance of :class:`datetime.datetime` indicating when the asset was modified"""
-        
+
         self.title = title
         """String containing the title of the asset"""
         self.subject = subject
@@ -156,23 +159,23 @@ class Asset(DaeObject):
         """String containing the name of the unit of distance for this asset"""
         self.unitmeter = unitmeter
         """Float containing how many real-world meters are in one distance unit"""
-        
+
         if upaxis is None:
             upaxis = UP_AXIS.Y_UP
         self.upaxis = upaxis
         """Instance of type :class:`collada.asset.UP_AXIS` indicating the up-axis of the asset"""
-        
+
         if contributors is None:
             contributors = []
         self.contributors = contributors
         """A list of instances of :class:`collada.asset.Contributor`"""
-        
+
         if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the asset."""
         else:
             self._recreateXmlNode()
-    
+
     def _recreateXmlNode(self):
         self.xmlnode = E.asset()
         for contributor in self.contributors:
@@ -194,36 +197,36 @@ class Asset(DaeObject):
     def save(self):
         """Saves the asset info back to :attr:`xmlnode`"""
         self._recreateXmlNode()
-        
+
     @staticmethod
     def load(collada, localscope, node):
         contributornodes = node.findall( tag('contributor') )
         contributors = []
         for contributornode in contributornodes:
             contributors.append(Contributor.load(collada, localscope, contributornode))
-        
+
         created = node.find( tag('created') )
         if created is not None:
             try: created = dateutil.parser.parse(created.text)
             except: created = None
-        
+
         keywords = node.find( tag('keywords') )
         if keywords is not None: keywords = keywords.text
-        
+
         modified = node.find( tag('modified') )
         if modified is not None:
             try: modified = dateutil.parser.parse(modified.text)
             except: modified = None
-            
+
         revision = node.find( tag('revision') )
         if revision is not None: revision = revision.text
-        
+
         subject = node.find( tag('subject') )
         if subject is not None: subject = subject.text
-        
+
         title = node.find( tag('title') )
         if title is not None: title = title.text
-        
+
         unitnode = node.find( tag('unit') )
         if unitnode is not None:
             unitname = unitnode.get('name')
@@ -234,15 +237,22 @@ class Asset(DaeObject):
         else:
             unitname = None
             unitmeter = None
-        
+
         upaxis = node.find( tag('up_axis') )
         if upaxis is not None:
             upaxis = upaxis.text
-            if not(upaxis == UP_AXIS.X_UP or upaxis == UP_AXIS.Y_UP or upaxis == UP_AXIS.Z_UP):
+            if not(upaxis == UP_AXIS.X_UP or upaxis == UP_AXIS.Y_UP or \
+                    upaxis == UP_AXIS.Z_UP):
                 upaxis = None
-        
-        return Asset(created=created, modified=modified, title=title, subject=subject, revision=revision,
-               keywords=keywords, unitname=unitname, unitmeter=unitmeter, upaxis=upaxis, contributors=contributors, xmlnode=node)
 
-    def __str__(self): return '<Asset title=%s>' % (str(self.title),)
-    def __repr__(self): return str(self)
+        return Asset(created=created, modified=modified, title=title,
+                subject=subject, revision=revision, keywords=keywords,
+                unitname=unitname, unitmeter=unitmeter, upaxis=upaxis,
+                contributors=contributors, xmlnode=node)
+
+    def __str__(self):
+        return '<Asset title=%s>' % (str(self.title),)
+
+    def __repr__(self):
+        return str(self)
+

--- a/collada/common.py
+++ b/collada/common.py
@@ -1,0 +1,81 @@
+from lxml import etree
+from lxml.builder import ElementMaker
+
+
+COLLADA_NS = 'http://www.collada.org/2005/11/COLLADASchema'
+E = ElementMaker(namespace=COLLADA_NS, nsmap={None: COLLADA_NS})
+
+
+def tag(text):
+    return str(etree.QName(COLLADA_NS, text))
+
+
+class DaeObject(object):
+    """This class is the abstract interface to all collada objects.
+
+    Every <tag> in a COLLADA that we recognize and load has mirror
+    class deriving from this one. All instances will have at least
+    a :meth:`load` method which creates the object from an xml node and
+    an attribute called :attr:`xmlnode` with the ElementTree representation
+    of the data. Even if it was created on the fly. If the object is
+    not read-only, it will also have a :meth:`save` method which saves the
+    object's information back to the :attr:`xmlnode` attribute.
+
+    """
+
+    xmlnode = None
+    """ElementTree representation of the data."""
+
+    @staticmethod
+    def load(collada, localscope, node):
+        """Load and return a class instance from an XML node.
+
+        Inspect the data inside node, which must match
+        this class tag and create an instance out of it.
+
+        :param collada.Collada collada:
+          The collada file object where this object lives
+        :param dict localscope:
+          If there is a local scope where we should look for local ids
+          (sid) this is the dictionary. Otherwise empty dict ({})
+        :param node:
+          An Element from python's ElementTree API
+
+        """
+        raise Exception('Not implemented')
+
+    def save(self):
+        """Put all the data to the internal xml node (xmlnode) so it can be serialized."""
+
+class DaeError(Exception):
+    """General DAE exception."""
+    def __init__(self, msg):
+        super(DaeError,self).__init__()
+        self.msg = msg
+
+    def __str__(self):
+        return type(self).__name__ + ': ' + self.msg
+
+    def __repr__(self):
+        return type(self).__name__ + '("' + self.msg + '")'
+
+class DaeIncompleteError(DaeError):
+    """Raised when needed data for an object isn't there."""
+    pass
+
+class DaeBrokenRefError(DaeError):
+    """Raised when a referenced object is not found in the scope."""
+    pass
+
+class DaeMalformedError(DaeError):
+    """Raised when data is found to be corrupted in some way."""
+    pass
+
+class DaeUnsupportedError(DaeError):
+    """Raised when some unexpectedly unsupported feature is found."""
+    pass
+
+class DaeSaveValidationError(DaeError):
+    """Raised when XML validation fails when saving."""
+    pass
+

--- a/collada/controller.py
+++ b/collada/controller.py
@@ -10,17 +10,20 @@
 #                                                                  #
 ####################################################################
 
-"""Contains objects representing controllers. Currently has partial 
+"""Contains objects representing controllers. Currently has partial
     support for loading Skin and Morph. **This module is highly
     experimental. More support will be added in version 0.4.**"""
 
-from lxml import etree as ElementTree
 import numpy
-import source
-from util import checkSource
-from collada import DaeObject, DaeIncompleteError, DaeBrokenRefError, \
-                    DaeMalformedError, DaeUnsupportedError, tag
+from lxml import etree as ElementTree
+
+from collada import source
+from collada.common import DaeObject, tag
+from collada.common import DaeIncompleteError, DaeBrokenRefError, \
+        DaeMalformedError, DaeUnsupportedError
 from collada.geometry import Geometry
+from collada.util import checkSource
+
 
 class Controller(DaeObject):
     """Base controller class holding data from <controller> tags."""
@@ -29,12 +32,12 @@ class Controller(DaeObject):
         pass
 
     @staticmethod
-    def load( collada, localscope, node ):        
+    def load( collada, localscope, node ):
         controller = node.find(tag('skin'))
         if controller is None:
             controller = node.find(tag('morph'))
         if controller is None: raise DaeUnsupportedError('Unknown controller node')
-        
+
         sourcebyid = {}
         sources = []
         sourcenodes = node.findall('%s/%s'%(controller.tag, tag('source')))
@@ -42,7 +45,7 @@ class Controller(DaeObject):
             ch = source.Source.load(collada, {}, sourcenode)
             sources.append(ch)
             sourcebyid[ch.id] = ch
-            
+
         if controller.tag == tag('skin'):
             return Skin.load(collada, sourcebyid, controller, node)
         else:
@@ -53,14 +56,14 @@ class BoundController( object ):
 
 class Skin(Controller):
     """Class containing data collada holds in the <skin> tag"""
-    
+
     def __init__(self, sourcebyid, bind_shape_matrix, joint_source, joint_matrix_source,
                  weight_source, weight_joint_source, vcounts, vertex_weight_index,
                  offsets, geometry, controller_node=None, skin_node=None):
         """Create a skin.
 
         :Parameters:
-          sourceById 
+          sourceById
             A dict mapping id's to a collada source
           bind_shape_matrix
             A numpy array of floats (pre-shape)
@@ -100,20 +103,20 @@ class Skin(Controller):
         self.controller_node = controller_node
         self.skin_node = skin_node
         self.xmlnode = controller_node
-        
+
         if not type(self.geometry) is Geometry:
             raise DaeMalformedError('Invalid reference geometry in skin')
-        
+
         self.id = controller_node.get('id')
         if self.id is None:
             raise DaeMalformedError('Controller node requires an ID')
-        
+
         self.nindices = max(self.offsets) + 1
-        
+
         if len(bind_shape_matrix) != 16:
             raise DaeMalformedError('Corrupted bind shape matrix in skin')
         self.bind_shape_matrix.shape = (4,4)
-        
+
         if not(joint_source in sourcebyid and joint_matrix_source in sourcebyid):
             raise DaeBrokenRefError("Input in joints not found")
         if not(type(sourcebyid[joint_source]) is source.NameSource or type(sourcebyid[joint_source]) is source.IDRefSource):
@@ -128,7 +131,7 @@ class Skin(Controller):
         self.joint_matrices = {}
         for n,m in zip(joint_names, joint_matrices):
             self.joint_matrices[n] = m
-        
+
         if not(weight_source in sourcebyid and weight_joint_source in sourcebyid):
             raise DaeBrokenRefError("Weights input in joints not found")
         if not type(sourcebyid[weight_source]) is source.FloatSource:
@@ -137,7 +140,7 @@ class Skin(Controller):
             raise DaeIncompleteError("Could not find weight joint source input for skin")
         self.weights = sourcebyid[weight_source]
         self.weight_joints = sourcebyid[weight_joint_source]
-        
+
         try:
             newshape = []
             at = 0
@@ -149,53 +152,61 @@ class Skin(Controller):
             self.index = newshape
         except:
             raise DaeMalformedError('Corrupted vcounts or index in skin weights')
-        
+
         try:
             self.joint_index = [influence[:, self.offsets[0]] for influence in self.index]
             self.weight_index = [influence[:, self.offsets[1]] for influence in self.index]
         except:
             raise DaeMalformedError('Corrupted joint or weight index in skin')
-        
+
         self.max_joint_index = numpy.max( [numpy.max(joint) if len(joint) > 0 else 0 for joint in self.joint_index] )
         self.max_weight_index = numpy.max( [numpy.max(weight) if len(weight) > 0 else 0 for weight in self.weight_index] )
         checkSource(self.weight_joints, ('JOINT',), self.max_joint_index)
         checkSource(self.weights, ('WEIGHT',), self.max_weight_index)
-    
-    def __len__(self): return len(self.index)
-    def __getitem__(self, i): return self.index[i]
-    
+
+    def __len__(self):
+        return len(self.index)
+
+    def __getitem__(self, i):
+        return self.index[i]
+
     def bind(self, matrix, materialnodebysymbol):
         """Create a bound morph from this one, transform and material mapping"""
         return BoundSkin(self, matrix, materialnodebysymbol)
-    
+
     @staticmethod
     def load( collada, localscope, skinnode, controllernode ):
         if len(localscope) < 3:
             raise DaeMalformedError('Not enough sources in skin')
-        
+
         geometry_source = skinnode.get('source')
-        if geometry_source is None or len(geometry_source) < 2 or geometry_source[0] != '#':
+        if geometry_source is None or len(geometry_source) < 2 \
+                or geometry_source[0] != '#':
             raise DaeBrokenRefError('Invalid source attribute of skin node')
         if not geometry_source[1:] in collada.geometries:
             raise DaeBrokenRefError('Source geometry for skin node not found')
         geometry = collada.geometries[geometry_source[1:]]
-        
+
         bind_shape_mat = skinnode.find(tag('bind_shape_matrix'))
         if bind_shape_mat is None:
             bind_shape_mat = numpy.identity(4, dtype=numpy.float32)
             bind_shape_mat.shape = (-1,)
         else:
-            try: values = [ float(v) for v in bind_shape_mat.text.split()]
-            except ValueError: raise DaeMalformedError('Corrupted bind shape matrix in skin')
+            try:
+                values = [ float(v) for v in bind_shape_mat.text.split()]
+            except ValueError:
+                raise DaeMalformedError('Corrupted bind shape matrix in skin')
             bind_shape_mat = numpy.array( values, dtype=numpy.float32 )
-        
+
         inputnodes = skinnode.findall('%s/%s'%(tag('joints'), tag('input')))
         if inputnodes is None or len(inputnodes) < 2:
             raise DaeIncompleteError("Not enough inputs in skin joints")
-        
-        try: inputs = [ (i.get('semantic'), i.get('source')) for i in inputnodes ]
-        except ValueError, ex: raise DaeMalformedError('Corrupted inputs in skin')
-        
+
+        try:
+            inputs = [(i.get('semantic'), i.get('source')) for i in inputnodes]
+        except ValueError as ex:
+            raise DaeMalformedError('Corrupted inputs in skin')
+
         joint_source = None
         matrix_source = None
         for i in inputs:
@@ -205,45 +216,52 @@ class Skin(Controller):
                 joint_source = i[1][1:]
             elif i[0] == 'INV_BIND_MATRIX':
                 matrix_source = i[1][1:]
-        
+
         weightsnode = skinnode.find(tag('vertex_weights'))
         if weightsnode is None:
             raise DaeIncompleteError("No vertex_weights found in skin")
         indexnode = weightsnode.find(tag('v'))
-        if indexnode is None: raise DaeIncompleteError('Missing indices in skin vertex weights')
+        if indexnode is None:
+            raise DaeIncompleteError('Missing indices in skin vertex weights')
         vcountnode = weightsnode.find(tag('vcount'))
-        if vcountnode is None: raise DaeIncompleteError('Missing vcount in skin vertex weights')
+        if vcountnode is None:
+            raise DaeIncompleteError('Missing vcount in skin vertex weights')
         inputnodes = weightsnode.findall(tag('input'))
 
-        try: 
-            index = numpy.array([float(v) for v in indexnode.text.split()], dtype=numpy.int32)
-            vcounts = numpy.array([int(v) for v in vcountnode.text.split()], dtype=numpy.int32)
-            inputs = [ (i.get('semantic'), i.get('source'), int(i.get('offset'))) 
-                           for i in inputnodes ]
-        except ValueError, ex: raise DaeMalformedError('Corrupted index or offsets in skin vertex weights')
-        
+        try:
+            index = numpy.array([float(v)
+                for v in indexnode.text.split()], dtype=numpy.int32)
+            vcounts = numpy.array([int(v)
+                for v in vcountnode.text.split()], dtype=numpy.int32)
+            inputs = [(i.get('semantic'), i.get('source'), int(i.get('offset')))
+                           for i in inputnodes]
+        except ValueError as ex:
+            raise DaeMalformedError('Corrupted index or offsets in skin vertex weights')
+
         weight_joint_source = None
         weight_source = None
         offsets = [0, 0]
         for i in inputs:
             if len(i[1]) < 2 or i[1][0] != '#':
-                raise DaeBrokenRefError('Input in skin node %s not found'%i[1])
+                raise DaeBrokenRefError('Input in skin node %s not found' % i[1])
             if i[0] == 'JOINT':
                 weight_joint_source = i[1][1:]
                 offsets[0] = i[2]
             elif i[0] == 'WEIGHT':
                 weight_source = i[1][1:]
                 offsets[1] = i[2]
-        
+
         if joint_source is None or weight_source is None:
-            raise DaeMalformedError('Not enough inputs for vertex weights in skin') 
-        
-        return Skin(localscope, bind_shape_mat, joint_source, matrix_source, weight_source, weight_joint_source,
-                    vcounts, index, offsets, geometry, controllernode, skinnode)
-    
+            raise DaeMalformedError('Not enough inputs for vertex weights in skin')
+
+        return Skin(localscope, bind_shape_mat, joint_source, matrix_source,
+                weight_source, weight_joint_source, vcounts, index, offsets,
+                geometry, controllernode, skinnode)
+
+
 class BoundSkin(BoundController):
     """A skin bound to a transform matrix and materials mapping."""
-    
+
     def __init__(self, skin, matrix, materialnodebysymbol):
         self.matrix = matrix
         self.materialnodebysymbol = materialnodebysymbol
@@ -252,36 +270,44 @@ class BoundSkin(BoundController):
         self.index = skin.index
         self.joint_matrices = skin.joint_matrices
         self.geometry = skin.geometry.bind(numpy.dot(matrix,skin.bind_shape_matrix), materialnodebysymbol)
-    
-    def __len__(self): return len(self.index)
-    def __getitem__(self, i): return self.index[i]
-    
-    def getJoint(self, i): return self.skin.weight_joints[i]
-    def getWeight(self, i): return self.skin.weights[i]
-    
+
+    def __len__(self):
+        return len(self.index)
+
+    def __getitem__(self, i):
+        return self.index[i]
+
+    def getJoint(self, i):
+        return self.skin.weight_joints[i]
+
+    def getWeight(self, i):
+        return self.skin.weights[i]
+
     def primitives(self):
         for prim in self.geometry.primitives():
             bsp = BoundSkinPrimitive(prim, self)
             yield bsp
-    
+
+
 class BoundSkinPrimitive(object):
     """A bound skin bound to a primitive."""
-    
+
     def __init__(self, primitive, boundskin):
         self.primitive = primitive
         self.boundskin = boundskin
-    
-    def __len__(self): return len(self.primitive)
-    
+
+    def __len__(self):
+        return len(self.primitive)
+
     def shapes(self):
         for shape in self.primitive.shapes():
             indices = shape.indices
-            
             yield shape
-    
+
+
 class Morph(Controller):
     """Class containing data collada holds in the <morph> tag"""
-    
+
     def __init__(self, source_geometry, target_list, xmlnode=None):
         """Create a morph instance
 
@@ -303,50 +329,57 @@ class Morph(Controller):
         self.target_list = target_list
         """A list of tuples where each tuple (g,w) contains
             a Geometry (g) and a float weight value (w)"""
-        
+
         self.xmlnode = xmlnode
         #TODO
 
-    def __len__(self): return len(self.target_list)
-    def __getitem__(self, i): return self.target_list[i]
-    
+    def __len__(self):
+        return len(self.target_list)
+
+    def __getitem__(self, i):
+        return self.target_list[i]
+
     def bind(self, matrix, materialnodebysymbol):
         """Create a bound morph from this one, transform and material mapping"""
         return BoundMorph(self, matrix, materialnodebysymbol)
-    
+
     @staticmethod
-    def load( collada, localscope, morphnode, controllernode ):        
+    def load( collada, localscope, morphnode, controllernode ):
         baseid = morphnode.get('source')
-        if len(baseid) < 2 or baseid[0] != '#' or not baseid[1:] in collada.geometries:
-            raise DaeBrokenRefError('Base source of morph %s not found'%baseid)
+        if len(baseid) < 2 or baseid[0] != '#' or \
+                not baseid[1:] in collada.geometries:
+            raise DaeBrokenRefError('Base source of morph %s not found' % baseid)
         basegeom = collada.geometries[baseid[1:]]
-        
+
         method = morphnode.get('method')
         if method is None:
             method = 'NORMALIZED'
         if not (method == 'NORMALIZED' or method == 'RELATIVE'):
             raise DaeMalformedError("Morph method must be either NORMALIZED or RELATIVE. Found '%s'" % method)
-        
+
         inputnodes = morphnode.findall('%s/%s'%(tag('targets'), tag('input')))
         if inputnodes is None or len(inputnodes) < 2:
             raise DaeIncompleteError("Not enough inputs in a morph")
-        
-        try: inputs = [ (i.get('semantic'), i.get('source')) for i in inputnodes ]
-        except ValueError, ex: raise DaeMalformedError('Corrupted inputs in morph')
-        
+
+        try:
+            inputs = [(i.get('semantic'), i.get('source')) for i in inputnodes]
+        except ValueError as ex:
+            raise DaeMalformedError('Corrupted inputs in morph')
+
         target_source = None
         weight_source = None
         for i in inputs:
             if len(i[1]) < 2 or i[1][0] != '#' or not i[1][1:] in localscope:
-                raise DaeBrokenRefError('Input in morph node %s not found'%i[1])
+                raise DaeBrokenRefError('Input in morph node %s not found' % i[1])
             if i[0] == 'MORPH_TARGET':
                 target_source = localscope[i[1][1:]]
             elif i[0] == 'MORPH_WEIGHT':
                 weight_source = localscope[i[1][1:]]
 
-        if not type(target_source) is source.IDRefSource or not type(weight_source) is source.FloatSource:
+        if not type(target_source) is source.IDRefSource or \
+                not type(weight_source) is source.FloatSource:
             raise DaeIncompleteError("Not enough inputs in targets of morph")
-        
+
         if len(target_source) != len(weight_source):
             raise DaeMalformedError("Morph inputs must be of same length")
 
@@ -357,21 +390,23 @@ class Morph(Controller):
             target_list.append((collada.geometries[target], weight[0]))
 
         return Morph(basegeom, target_list, controllernode)
-    
+
     def save(self):
         #TODO
         pass
-        
+
+
 class BoundMorph(BoundController):
     """A morph bound to a transform matrix and materials mapping."""
-    
+
     def __init__(self, morph, matrix, materialnodebysymbol):
         self.matrix = matrix
         self.materialnodebysymbol = materialnodebysymbol
         self.original = morph
-    
-    def __len__(self): return len(self.original)
-    
+
+    def __len__(self):
+        return len(self.original)
+
     def __getitem__(self, i):
         return self.original[i]
-    
+

--- a/collada/lineset.py
+++ b/collada/lineset.py
@@ -14,11 +14,13 @@
 
 import numpy
 from lxml import etree as ElementTree
-import primitive
-import types
-from util import toUnitVec, checkSource
-from collada import DaeIncompleteError, DaeBrokenRefError, DaeMalformedError, \
-                    DaeUnsupportedError, tag, E
+
+from collada import primitive
+from collada.util import toUnitVec, checkSource
+from collada.common import E, tag
+from collada.common import DaeIncompleteError, DaeBrokenRefError, \
+        DaeMalformedError, DaeUnsupportedError
+
 
 class Line(object):
     """Single line representation. Represents the line between two points
@@ -43,15 +45,18 @@ class Line(object):
 
         # Note: we can't generate normals for lines if there are none
 
-    def __repr__(self): 
+    def __repr__(self):
         return '<Line (%s, %s, "%s")>'%(str(self.vertices[0]), str(self.vertices[1]), str(self.material))
-    def __str__(self): return repr(self)
+
+    def __str__(self):
+        return repr(self)
+
 
 class LineSet(primitive.Primitive):
     """Class containing the data COLLADA puts in a <lines> tag, a collection of
     lines. The LineSet object is read-only. To modify a LineSet, create a new
     instance using :meth:`collada.geometry.Geometry.createLineSet`.
-    
+
     * If ``L`` is an instance of :class:`collada.lineset.LineSet`, then ``len(L)``
       returns the number of lines in the set. ``L[i]`` returns the i\ :sup:`th`
       line in the set."""
@@ -67,7 +72,7 @@ class LineSet(primitive.Primitive):
 
         #find max offset
         max_offset = max([ max([input[0] for input in input_type_array])
-                          for input_type_array in sources.itervalues() if len(input_type_array) > 0])
+                          for input_type_array in sources.values() if len(input_type_array) > 0])
 
         self.sources = sources
         self.material = material
@@ -81,34 +86,40 @@ class LineSet(primitive.Primitive):
             self._vertex = sources['VERTEX'][0][4].data
             self._vertex_index = self.index[:,:, sources['VERTEX'][0][0]]
             self.maxvertexindex = numpy.max( self._vertex_index )
-            checkSource(sources['VERTEX'][0][4], ('X', 'Y', 'Z'), self.maxvertexindex)
+            checkSource(sources['VERTEX'][0][4], ('X', 'Y', 'Z'),
+                    self.maxvertexindex)
         else:
             self._vertex = None
             self._vertex_index = None
             self.maxvertexindex = -1
 
-        if 'NORMAL' in sources and len(sources['NORMAL']) > 0 and len(self.index) > 0:
+        if 'NORMAL' in sources and len(sources['NORMAL']) > 0 \
+                and len(self.index) > 0:
             self._normal = sources['NORMAL'][0][4].data
             self._normal_index = self.index[:,:, sources['NORMAL'][0][0]]
             self.maxnormalindex = numpy.max( self._normal_index )
-            checkSource(sources['NORMAL'][0][4], ('X', 'Y', 'Z'), self.maxnormalindex)
+            checkSource(sources['NORMAL'][0][4], ('X', 'Y', 'Z'),
+                    self.maxnormalindex)
         else:
             self._normal = None
             self._normal_index = None
             self.maxnormalindex = -1
-            
-        if 'TEXCOORD' in sources and len(sources['TEXCOORD']) > 0 and len(self.index) > 0:
-            self._texcoordset = tuple([texinput[4].data for texinput in sources['TEXCOORD']])
+
+        if 'TEXCOORD' in sources and len(sources['TEXCOORD']) > 0 \
+                and len(self.index) > 0:
+            self._texcoordset = tuple([texinput[4].data
+                for texinput in sources['TEXCOORD']])
             self._texcoord_indexset = tuple([ self.index[:,:, sources['TEXCOORD'][i][0]]
-                                             for i in xrange(len(sources['TEXCOORD'])) ])
-            self.maxtexcoordsetindex = [ numpy.max( tex_index ) for tex_index in self._texcoord_indexset ]
+                for i in xrange(len(sources['TEXCOORD'])) ])
+            self.maxtexcoordsetindex = [numpy.max(tex_index)
+                for tex_index in self._texcoord_indexset]
             for i, texinput in enumerate(sources['TEXCOORD']):
                 checkSource(texinput[4], ('S', 'T'), self.maxtexcoordsetindex[i])
         else:
             self._texcoordset = tuple()
             self._texcoord_indexset = tuple()
             self.maxtexcoordsetindex = -1
-            
+
         if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the line set."""
@@ -117,22 +128,25 @@ class LineSet(primitive.Primitive):
             acclen = len(self.index)
             txtindices = ' '.join(map(str, self.index.tolist()))
             self.index.shape = (-1, 2, self.nindices)
-            
-            self.xmlnode = E.lines(count=str(self.nlines), material=self.material)
-            
+
+            self.xmlnode = E.lines(count=str(self.nlines),
+                    material=self.material)
+
             all_inputs = []
-            for semantic_list in self.sources.itervalues():
+            for semantic_list in self.sources.values():
                 all_inputs.extend(semantic_list)
             for offset, semantic, sourceid, set, src in all_inputs:
-                inpnode = E.input(offset=str(offset), semantic=semantic, source=sourceid)
+                inpnode = E.input(offset=str(offset), semantic=semantic,
+                        source=sourceid)
                 if set is not None:
                     inpnode.set('set', str(set))
                 self.xmlnode.append(inpnode)
-            
+
             self.xmlnode.append(E.p(txtindices))
 
-    def __len__(self): return len(self.index)
-    """The number of lines in this line set."""
+    def __len__(self):
+        """The number of lines in this line set."""
+        return len(self.index)
 
     def __getitem__(self, i):
         v = self._vertex[ self._vertex_index[i] ]
@@ -149,9 +163,9 @@ class LineSet(primitive.Primitive):
     def load( collada, localscope, node ):
         indexnode = node.find(tag('p'))
         if indexnode is None: raise DaeIncompleteError('Missing index in line set')
-        
+
         source_array = primitive.Primitive._getInputs(collada, localscope, node.findall(tag('input')))
-            
+
         try:
             if indexnode.text is None:
                 index = numpy.array([],  dtype=numpy.int32)
@@ -159,21 +173,25 @@ class LineSet(primitive.Primitive):
                 index = numpy.fromstring(indexnode.text, dtype=numpy.int32, sep=' ')
             index[numpy.isnan(index)] = 0
         except: raise DaeMalformedError('Corrupted index in line set')
-        
+
         lineset = LineSet(source_array, node.get('material'), index, node)
         lineset.xmlnode = node
         return lineset
-    
+
     def bind(self, matrix, materialnodebysymbol):
         """Create a bound line set from this line set, transform and material mapping"""
         return BoundLineSet( self, matrix, materialnodebysymbol)
 
-    def __str__(self): return '<LineSet length=%d>' % len(self)
-    def __repr__(self): return str(self)
+    def __str__(self):
+        return '<LineSet length=%d>' % len(self)
+
+    def __repr__(self):
+        return str(self)
+
 
 class BoundLineSet(primitive.BoundPrimitive):
     """A line set bound to a transform matrix and materials mapping.
-    
+
     * If ``bs`` is an instance of :class:`collada.lineset.BoundLineSet`, ``len(bs)``
       returns the number of lines in the set and ``bs[i]`` returns the i\ :superscript:`th`
       line in the set.
@@ -184,13 +202,18 @@ class BoundLineSet(primitive.BoundPrimitive):
         """Create a bound line set from a line set, transform and material mapping. This gets created when a
         line set is instantiated in a scene. Do not create this manually."""
         M = numpy.asmatrix(matrix).transpose()
-        self._vertex = None if ls._vertex is None else numpy.asarray(ls._vertex * M[:3,:3]) + matrix[:3,3]
-        self._normal = None if ls._normal is None else numpy.asarray(ls._normal * M[:3,:3])
+        self._vertex = None
+        if ls._vertex is not None:
+            self._vertex = numpy.asarray(ls._vertex * M[:3,:3]) + matrix[:3,3]
+        self._normal = None
+        if ls._normal is not None:
+            self._normal = numpy.asarray(ls._normal * M[:3,:3])
         self._texcoordset = ls._texcoordset
         matnode = materialnodebysymbol.get( ls.material )
         if matnode:
             self.material = matnode.target
-            self.inputmap = dict([ (sem, (input_sem, set)) for sem, input_sem, set in matnode.inputs ])
+            self.inputmap = dict([ (sem, (input_sem, set))
+                for sem, input_sem, set in matnode.inputs ])
         else: self.inputmap = self.material = None
         self.index = ls.index
         self._vertex_index = ls._vertex_index
@@ -198,8 +221,9 @@ class BoundLineSet(primitive.BoundPrimitive):
         self._texcoord_indexset = ls._texcoord_indexset
         self.nlines = ls.nlines
         self.original = ls
-    
-    def __len__(self): return len(self.index)
+
+    def __len__(self):
+        return len(self.index)
 
     def __getitem__(self, i):
         v = self._vertex[ self._vertex_index[i] ]
@@ -214,17 +238,21 @@ class BoundLineSet(primitive.BoundPrimitive):
 
     def lines(self):
         """Iterate through all the lines contained in the set.
-        
+
         :rtype: generator of :class:`collada.lineset.Line`
         """
         for i in xrange(self.nlines): yield self[i]
 
     def shapes(self):
         """Iterate through all the lines contained in the set.
-        
+
         :rtype: generator of :class:`collada.lineset.Line`
         """
         return self.lines()
 
-    def __str__(self): return '<BoundLineSet length=%d>' % len(self)
-    def __repr__(self): return str(self)
+    def __str__(self):
+        return '<BoundLineSet length=%d>' % len(self)
+
+    def __repr__(self):
+        return str(self)
+

--- a/collada/polygons.py
+++ b/collada/polygons.py
@@ -14,24 +14,26 @@
 
 import numpy
 from lxml import etree as ElementTree
-import primitive
-import types
-import triangleset
-import polylist
-from util import toUnitVec, checkSource
-from collada import DaeIncompleteError, DaeBrokenRefError, DaeMalformedError, \
-                    DaeUnsupportedError, tag, E
+
+from collada import primitive
+from collada import polylist
+from collada import triangleset
+from collada.util import toUnitVec, checkSource
+from collada.common import E, tag
+from collada.common import DaeIncompleteError, DaeBrokenRefError, \
+        DaeMalformedError, DaeUnsupportedError
+
 
 class Polygons(polylist.Polylist):
     """Class containing the data COLLADA puts in a <polygons> tag, a collection of
     polygons that can have holes.
-    
+
     * The Polygons object is read-only. To modify a
       Polygons, create a new instance using :meth:`collada.geometry.Geometry.createPolygons`.
-    
+
     * Polygons with holes are not currently supported, so for right now, this class is
       essentially the same as a :class:`collada.polylist.Polylist`. Use a polylist instead
-      if your polygons don't have holes. 
+      if your polygons don't have holes.
     """
 
     def __init__(self, sources, material, polygons, xmlnode=None):
@@ -39,10 +41,11 @@ class Polygons(polylist.Polylist):
         :meth:`collada.geometry.Geometry.createPolygons` method after
         creating a geometry instance.
         """
-        
+
         max_offset = max([ max([input[0] for input in input_type_array])
-                          for input_type_array in sources.itervalues() if len(input_type_array) > 0])
-        
+            for input_type_array in sources.values()
+            if len(input_type_array) > 0])
+
         vcounts = numpy.zeros(len(polygons), dtype=numpy.int32)
         for i, poly in enumerate(polygons):
             vcounts[i] = len(poly) / (max_offset + 1)
@@ -53,22 +56,22 @@ class Polygons(polylist.Polylist):
             indices = numpy.array([], dtype=numpy.int32)
 
         super(Polygons, self).__init__(sources, material, indices, vcounts, xmlnode)
-        
+
         if xmlnode is not None: self.xmlnode = xmlnode
         else:
-            acclen = len(polygons) 
+            acclen = len(polygons)
 
             self.xmlnode = E.polygons(count=str(acclen), material=self.material)
-            
+
             all_inputs = []
-            for semantic_list in self.sources.itervalues():
+            for semantic_list in self.sources.values():
                 all_inputs.extend(semantic_list)
             for offset, semantic, sourceid, set, src in all_inputs:
                 inpnode = E.input(offset=str(offset), semantic=semantic, source=sourceid)
                 if set is not None:
                     inpnode.set('set', str(set))
                 self.xmlnode.append(inpnode)
-            
+
             for poly in polygons:
                 self.xmlnode.append(E.p(' '.join(map(str, poly.flatten().tolist()))))
 
@@ -82,18 +85,22 @@ class Polygons(polylist.Polylist):
             index = numpy.fromstring(indexnode.text, dtype=numpy.int32, sep=' ')
             index[numpy.isnan(index)] = 0
             polygon_indices.append(index)
-        
+
         all_inputs = primitive.Primitive._getInputs(collada, localscope, node.findall(tag('input')))
 
         polygons = Polygons(all_inputs, node.get('material'), polygon_indices, node)
         return polygons
-    
+
     def bind(self, matrix, materialnodebysymbol):
         """Create a bound polygons from this polygons, transform and material mapping"""
         return BoundPolygons( self, matrix, materialnodebysymbol )
 
-    def __str__(self): return '<Polygons length=%d>' % len(self)
-    def __repr__(self): return str(self)
+    def __str__(self):
+        return '<Polygons length=%d>' % len(self)
+
+    def __repr__(self):
+        return str(self)
+
 
 class BoundPolygons(polylist.BoundPolylist):
     """Polygons bound to a transform matrix and materials mapping."""
@@ -102,5 +109,9 @@ class BoundPolygons(polylist.BoundPolylist):
         """Create a BoundPolygons from a Polygons, transform and material mapping"""
         super(BoundPolygons, self).__init__(pl, matrix, materialnodebysymbol)
 
-    def __str__(self): return '<BoundPolygons length=%d>' % len(self)
-    def __repr__(self): return str(self)
+    def __str__(self):
+        return '<BoundPolygons length=%d>' % len(self)
+
+    def __repr__(self):
+        return str(self)
+

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -15,7 +15,7 @@
 with the COLLADA 1.4.1 schema."""
 
 import lxml
-import StringIO
+from collada.util import bytes, BytesIO
 
 COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns="http://www.collada.org/2005/11/COLLADASchema" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" targetNamespace="http://www.collada.org/2005/11/COLLADASchema" elementFormDefault="qualified" version="1.4.1" xml:lang="EN" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema http://www.w3.org/2001/XMLSchema.xsd">
@@ -31,9 +31,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
              Khronos is a trademark of The Khronos Group Inc.
              COLLADA is a trademark of Sony Computer Entertainment Inc. used by permission by Khronos.
 
-             Note that this software document is distributed on an "AS IS" basis, with ALL EXPRESS AND 
+             Note that this software document is distributed on an "AS IS" basis, with ALL EXPRESS AND
              IMPLIED WARRANTIES AND CONDITIONS DISCLAIMED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED
-             WARRANTIES AND CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR 
+             WARRANTIES AND CONDITIONS OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR
              PURPOSE, AND NON-INFRINGEMENT.
         </xs:documentation>
     </xs:annotation>
@@ -44,7 +44,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:annotation>
             <xs:appinfo>enable-xmlns</xs:appinfo>
             <xs:documentation>
-            The COLLADA element declares the root of the document that comprises some of the content 
+            The COLLADA element declares the root of the document that comprises some of the content
             in the COLLADA schema.
             </xs:documentation>
         </xs:annotation>
@@ -167,9 +167,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="scene" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        The scene embodies the entire set of information that can be visualized from the 
-                        contents of a COLLADA resource. The scene element declares the base of the scene 
-                        hierarchy or scene graph. The scene contains elements that comprise much of the 
+                        The scene embodies the entire set of information that can be visualized from the
+                        contents of a COLLADA resource. The scene element declares the base of the scene
+                        hierarchy or scene graph. The scene contains elements that comprise much of the
                         visual and transformational information content as created by the authoring tools.
                         </xs:documentation>
                     </xs:annotation>
@@ -212,7 +212,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="version" type="VersionType" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                        The version attribute is the COLLADA schema revision with which the instance document 
+                        The version attribute is the COLLADA schema revision with which the instance document
                         conforms. Required Attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -516,8 +516,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="offset" type="uint" use="required">
             <xs:annotation>
                 <xs:documentation>
-                The offset attribute represents the offset into the list of indices.  If two input elements share 
-                the same offset, they will be indexed the same.  This works as a simple form of compression for the 
+                The offset attribute represents the offset into the list of indices.  If two input elements share
+                the same offset, they will be indexed the same.  This works as a simple form of compression for the
                 list of indices as well as defining the order the inputs should be used in.  Required attribute.
                 </xs:documentation>
             </xs:annotation>
@@ -539,8 +539,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="set" type="uint">
             <xs:annotation>
                 <xs:documentation>
-                The set attribute indicates which inputs should be grouped together as a single set. This is helpful 
-                when multiple inputs share the same semantics. 
+                The set attribute indicates which inputs should be grouped together as a single set. This is helpful
+                when multiple inputs share the same semantics.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -548,7 +548,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:complexType name="InstanceWithExtra">
         <xs:annotation>
             <xs:documentation>
-            The InstanceWithExtra type is used for all generic instance elements. A generic instance element 
+            The InstanceWithExtra type is used for all generic instance elements. A generic instance element
             is one which does not have any specific child elements declared.
             </xs:documentation>
         </xs:annotation>
@@ -564,8 +564,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="url" type="xs:anyURI" use="required">
             <xs:annotation>
                 <xs:documentation>
-                The url attribute refers to resource to instantiate. This may refer to a local resource using a 
-                relative URL fragment identifier that begins with the “#” character. The url attribute may refer 
+                The url attribute refers to resource to instantiate. This may refer to a local resource using a
+                relative URL fragment identifier that begins with the “#” character. The url attribute may refer
                 to an external resource using an absolute or relative URL.
                 </xs:documentation>
             </xs:annotation>
@@ -573,7 +573,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="sid" type="xs:NCName">
             <xs:annotation>
                 <xs:documentation>
-                The sid attribute is a text string value containing the sub-identifier of this element. This 
+                The sid attribute is a text string value containing the sub-identifier of this element. This
                 value must be unique within the scope of the parent element. Optional attribute.
                 </xs:documentation>
             </xs:annotation>
@@ -589,7 +589,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:complexType name="TargetableFloat">
         <xs:annotation>
             <xs:documentation>
-            The TargetableFloat type is used to represent elements which contain a single float value which can 
+            The TargetableFloat type is used to represent elements which contain a single float value which can
             be targeted for animation.
             </xs:documentation>
         </xs:annotation>
@@ -598,7 +598,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:attribute name="sid" type="xs:NCName">
                     <xs:annotation>
                         <xs:documentation>
-                        The sid attribute is a text string value containing the sub-identifier of this element. This 
+                        The sid attribute is a text string value containing the sub-identifier of this element. This
                         value must be unique within the scope of the parent element. Optional attribute.
                         </xs:documentation>
                     </xs:annotation>
@@ -609,7 +609,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:complexType name="TargetableFloat3">
         <xs:annotation>
             <xs:documentation>
-            The TargetableFloat3 type is used to represent elements which contain a float3 value which can 
+            The TargetableFloat3 type is used to represent elements which contain a float3 value which can
             be targeted for animation.
             </xs:documentation>
         </xs:annotation>
@@ -618,7 +618,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:attribute name="sid" type="xs:NCName">
                     <xs:annotation>
                         <xs:documentation>
-                        The sid attribute is a text string value containing the sub-identifier of this element. 
+                        The sid attribute is a text string value containing the sub-identifier of this element.
                         This value must be unique within the scope of the parent element. Optional attribute.
                         </xs:documentation>
                     </xs:annotation>
@@ -639,7 +639,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="id" type="xs:ID">
                         <xs:annotation>
                             <xs:documentation>
-                            The id attribute is a text string containing the unique identifier of this element. This value 
+                            The id attribute is a text string containing the unique identifier of this element. This value
                             must be unique within the instance document. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -674,7 +674,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="id" type="xs:ID">
                         <xs:annotation>
                             <xs:documentation>
-                            The id attribute is a text string containing the unique identifier of this element. 
+                            The id attribute is a text string containing the unique identifier of this element.
                             This value must be unique within the instance document. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -709,7 +709,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="id" type="xs:ID">
                         <xs:annotation>
                             <xs:documentation>
-                            The id attribute is a text string containing the unique identifier of this element. 
+                            The id attribute is a text string containing the unique identifier of this element.
                             This value must be unique within the instance document. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -744,7 +744,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="id" type="xs:ID">
                         <xs:annotation>
                             <xs:documentation>
-                            The id attribute is a text string containing the unique identifier of this element. This value 
+                            The id attribute is a text string containing the unique identifier of this element. This value
                             must be unique within the instance document. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -766,7 +766,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="digits" type="xs:short" default="6">
                         <xs:annotation>
                             <xs:documentation>
-                            The digits attribute indicates the number of significant decimal digits of the float values that 
+                            The digits attribute indicates the number of significant decimal digits of the float values that
                             can be contained in the array. The default value is 6. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -774,7 +774,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="magnitude" type="xs:short" default="38">
                         <xs:annotation>
                             <xs:documentation>
-                            The magnitude attribute indicates the largest exponent of the float values that can be contained 
+                            The magnitude attribute indicates the largest exponent of the float values that can be contained
                             in the array. The default value is 38. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -795,7 +795,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="id" type="xs:ID">
                         <xs:annotation>
                             <xs:documentation>
-                            The id attribute is a text string containing the unique identifier of this element. 
+                            The id attribute is a text string containing the unique identifier of this element.
                             This value must be unique within the instance document. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -817,7 +817,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="minInclusive" type="xs:integer" default="-2147483648">
                         <xs:annotation>
                             <xs:documentation>
-                            The minInclusive attribute indicates the smallest integer value that can be contained in 
+                            The minInclusive attribute indicates the smallest integer value that can be contained in
                             the array. The default value is –2147483648. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -825,7 +825,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="maxInclusive" type="xs:integer" default="2147483647">
                         <xs:annotation>
                             <xs:documentation>
-                            The maxInclusive attribute indicates the largest integer value that can be contained in 
+                            The maxInclusive attribute indicates the largest integer value that can be contained in
                             the array. The default value is 2147483647. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -838,9 +838,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="accessor">
         <xs:annotation>
             <xs:documentation>
-            The accessor element declares an access pattern to one of the array elements: float_array, 
-            int_array, Name_array, bool_array, and IDREF_array. The accessor element describes access 
-            to arrays that are organized in either an interleaved or non-interleaved manner, depending 
+            The accessor element declares an access pattern to one of the array elements: float_array,
+            int_array, Name_array, bool_array, and IDREF_array. The accessor element describes access
+            to arrays that are organized in either an interleaved or non-interleaved manner, depending
             on the offset and stride attributes.
             </xs:documentation>
         </xs:annotation>
@@ -864,7 +864,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="offset" type="uint" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                    The offset attribute indicates the index of the first value to be read from the array. 
+                    The offset attribute indicates the index of the first value to be read from the array.
                     The default value is 0. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -879,7 +879,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="stride" type="uint" default="1">
                 <xs:annotation>
                     <xs:documentation>
-                    The stride attribute indicates number of values to be considered a unit during each access to 
+                    The stride attribute indicates number of values to be considered a unit during each access to
                     the array. The default value is 1, indicating that a single value is accessed. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -905,7 +905,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="sid" type="xs:NCName">
                         <xs:annotation>
                             <xs:documentation>
-                            The sid attribute is a text string value containing the sub-identifier of this element. 
+                            The sid attribute is a text string value containing the sub-identifier of this element.
                             This value must be unique within the scope of the parent element. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -920,7 +920,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="type" type="xs:NMTOKEN" use="required">
                         <xs:annotation>
                             <xs:documentation>
-                            The type attribute indicates the type of the value data. This text string must be understood 
+                            The type attribute indicates the type of the value data. This text string must be understood
                             by the application. Required attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -932,7 +932,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="source">
         <xs:annotation>
             <xs:documentation>
-            The source element declares a data repository that provides values according to the semantics of an 
+            The source element declares a data repository that provides values according to the semantics of an
             input element that refers to it.
             </xs:documentation>
         </xs:annotation>
@@ -1011,7 +1011,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Required attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1030,8 +1030,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:annotation>
             <xs:documentation>
             Geometry describes the visual shape and appearance of an object in the scene.
-            The geometry element categorizes the declaration of geometric information. Geometry is a 
-            branch of mathematics that deals with the measurement, properties, and relationships of 
+            The geometry element categorizes the declaration of geometric information. Geometry is a
+            branch of mathematics that deals with the measurement, properties, and relationships of
             points, lines, angles, surfaces, and solids.
             </xs:documentation>
         </xs:annotation>
@@ -1072,7 +1072,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1222,8 +1222,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="p" type="ListOfUInts">
         <xs:annotation>
             <xs:documentation>
-            The p element represents primitive data for the primitive types (lines, linestrips, polygons, 
-            polylist, triangles, trifans, tristrips). The p element contains indices that reference into 
+            The p element represents primitive data for the primitive types (lines, linestrips, polygons,
+            polylist, triangles, trifans, tristrips). The p element contains indices that reference into
             the parent's source elements referenced by the input elements.
             </xs:documentation>
         </xs:annotation>
@@ -1231,9 +1231,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="lines">
         <xs:annotation>
             <xs:documentation>
-            The lines element provides the information needed to bind vertex attributes together and then 
-            organize those vertices into individual lines. Each line described by the mesh has two vertices. 
-            The first line is formed from first and second vertices. The second line is formed from the 
+            The lines element provides the information needed to bind vertex attributes together and then
+            organize those vertices into individual lines. Each line described by the mesh has two vertices.
+            The first line is formed from first and second vertices. The second line is formed from the
             third and fourth vertices and so on.
             </xs:documentation>
         </xs:annotation>
@@ -1242,7 +1242,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="input" type="InputLocalOffset" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                        The input element may occur any number of times. This input is a local input with the offset 
+                        The input element may occur any number of times. This input is a local input with the offset
                         and set attributes.
                         </xs:documentation>
                     </xs:annotation>
@@ -1279,8 +1279,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="material" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The material attribute declares a symbol for a material. This symbol is bound to a material at 
-                    the time of instantiation. If the material attribute is not specified then the lighting and 
+                    The material attribute declares a symbol for a material. This symbol is bound to a material at
+                    the time of instantiation. If the material attribute is not specified then the lighting and
                     shading results are application defined. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1290,9 +1290,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="linestrips">
         <xs:annotation>
             <xs:documentation>
-            The linestrips element provides the information needed to bind vertex attributes together and 
-            then organize those vertices into connected line-strips. Each line-strip described by the mesh 
-            has an arbitrary number of vertices. Each line segment within the line-strip is formed from the 
+            The linestrips element provides the information needed to bind vertex attributes together and
+            then organize those vertices into connected line-strips. Each line-strip described by the mesh
+            has an arbitrary number of vertices. Each line segment within the line-strip is formed from the
             current vertex and the preceding vertex.
             </xs:documentation>
         </xs:annotation>
@@ -1301,7 +1301,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="input" type="InputLocalOffset" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                        The input element may occur any number of times. This input is a local input with the offset 
+                        The input element may occur any number of times. This input is a local input with the offset
                         and set attributes.
                         </xs:documentation>
                     </xs:annotation>
@@ -1338,8 +1338,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="material" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The material attribute declares a symbol for a material. This symbol is bound to a material 
-                    at the time of instantiation. If the material attribute is not specified then the lighting 
+                    The material attribute declares a symbol for a material. This symbol is bound to a material
+                    at the time of instantiation. If the material attribute is not specified then the lighting
                     and shading results are application defined. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1349,8 +1349,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="polygons">
         <xs:annotation>
             <xs:documentation>
-            The polygons element provides the information needed to bind vertex attributes together and 
-            then organize those vertices into individual polygons. The polygons described can contain 
+            The polygons element provides the information needed to bind vertex attributes together and
+            then organize those vertices into individual polygons. The polygons described can contain
             arbitrary numbers of vertices. These polygons may be self intersecting and may also contain holes.
             </xs:documentation>
         </xs:annotation>
@@ -1359,7 +1359,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="input" type="InputLocalOffset" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                        The input element may occur any number of times. This input is a local input with the 
+                        The input element may occur any number of times. This input is a local input with the
                         offset and set attributes.
                         </xs:documentation>
                     </xs:annotation>
@@ -1423,9 +1423,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="material" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The material attribute declares a symbol for a material. This symbol is bound to a material 
-                    at the time of instantiation. If the material attribute is not specified then the lighting 
-                    and shading results are application defined. Optional attribute. 
+                    The material attribute declares a symbol for a material. This symbol is bound to a material
+                    at the time of instantiation. If the material attribute is not specified then the lighting
+                    and shading results are application defined. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
@@ -1434,9 +1434,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="polylist">
         <xs:annotation>
             <xs:documentation>
-            The polylist element provides the information needed to bind vertex attributes together and 
-            then organize those vertices into individual polygons. The polygons described in polylist can 
-            contain arbitrary numbers of vertices. Unlike the polygons element, the polylist element cannot 
+            The polylist element provides the information needed to bind vertex attributes together and
+            then organize those vertices into individual polygons. The polygons described in polylist can
+            contain arbitrary numbers of vertices. Unlike the polygons element, the polylist element cannot
             contain polygons with holes.
             </xs:documentation>
         </xs:annotation>
@@ -1445,7 +1445,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="input" type="InputLocalOffset" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                        The input element may occur any number of times. This input is a local input with the 
+                        The input element may occur any number of times. This input is a local input with the
                         offset and set attributes.
                         </xs:documentation>
                     </xs:annotation>
@@ -1453,7 +1453,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="vcount" type="ListOfUInts" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        The vcount element contains a list of integers describing the number of sides for each polygon 
+                        The vcount element contains a list of integers describing the number of sides for each polygon
                         described by the polylist element. The vcount element may occur once.
                         </xs:documentation>
                     </xs:annotation>
@@ -1490,8 +1490,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="material" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The material attribute declares a symbol for a material. This symbol is bound to a material at 
-                    the time of instantiation. If the material attribute is not specified then the lighting and 
+                    The material attribute declares a symbol for a material. This symbol is bound to a material at
+                    the time of instantiation. If the material attribute is not specified then the lighting and
                     shading results are application defined. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1501,9 +1501,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="triangles">
         <xs:annotation>
             <xs:documentation>
-            The triangles element provides the information needed to bind vertex attributes together and 
-            then organize those vertices into individual triangles.    Each triangle described by the mesh has 
-            three vertices. The first triangle is formed from the first, second, and third vertices. The 
+            The triangles element provides the information needed to bind vertex attributes together and
+            then organize those vertices into individual triangles.    Each triangle described by the mesh has
+            three vertices. The first triangle is formed from the first, second, and third vertices. The
             second triangle is formed from the fourth, fifth, and sixth vertices, and so on.
             </xs:documentation>
         </xs:annotation>
@@ -1512,7 +1512,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="input" type="InputLocalOffset" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                        The input element may occur any number of times. This input is a local input with the 
+                        The input element may occur any number of times. This input is a local input with the
                         offset and set attributes.
                         </xs:documentation>
                     </xs:annotation>
@@ -1549,8 +1549,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="material" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The material attribute declares a symbol for a material. This symbol is bound to a material at 
-                    the time of instantiation. Optional attribute. If the material attribute is not specified then 
+                    The material attribute declares a symbol for a material. This symbol is bound to a material at
+                    the time of instantiation. Optional attribute. If the material attribute is not specified then
                     the lighting and shading results are application defined.
                     </xs:documentation>
                 </xs:annotation>
@@ -1560,9 +1560,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="trifans">
         <xs:annotation>
             <xs:documentation>
-            The trifans element provides the information needed to bind vertex attributes together and then 
-            organize those vertices into connected triangles. Each triangle described by the mesh has three 
-            vertices. The first triangle is formed from first, second, and third vertices. Each subsequent 
+            The trifans element provides the information needed to bind vertex attributes together and then
+            organize those vertices into connected triangles. Each triangle described by the mesh has three
+            vertices. The first triangle is formed from first, second, and third vertices. Each subsequent
             triangle is formed from the current vertex, reusing the first and the previous vertices.
             </xs:documentation>
         </xs:annotation>
@@ -1571,7 +1571,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="input" type="InputLocalOffset" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                        The input element may occur any number of times. This input is a local input with the 
+                        The input element may occur any number of times. This input is a local input with the
                         offset and set attributes.
                         </xs:documentation>
                     </xs:annotation>
@@ -1608,8 +1608,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="material" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The material attribute declares a symbol for a material. This symbol is bound to a material 
-                    at the time of instantiation. If the material attribute is not specified then the lighting 
+                    The material attribute declares a symbol for a material. This symbol is bound to a material
+                    at the time of instantiation. If the material attribute is not specified then the lighting
                     and shading results are application defined. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1619,9 +1619,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="tristrips">
         <xs:annotation>
             <xs:documentation>
-            The tristrips element provides the information needed to bind vertex attributes together and then 
-            organize those vertices into connected triangles. Each triangle described by the mesh has three 
-            vertices. The first triangle is formed from first, second, and third vertices. Each subsequent 
+            The tristrips element provides the information needed to bind vertex attributes together and then
+            organize those vertices into connected triangles. Each triangle described by the mesh has three
+            vertices. The first triangle is formed from first, second, and third vertices. Each subsequent
             triangle is formed from the current vertex, reusing the previous two vertices.
             </xs:documentation>
         </xs:annotation>
@@ -1630,7 +1630,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="input" type="InputLocalOffset" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                        The input element may occur any number of times. This input is a local input with the offset 
+                        The input element may occur any number of times. This input is a local input with the offset
                         and set attributes.
                         </xs:documentation>
                     </xs:annotation>
@@ -1667,8 +1667,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="material" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The material attribute declares a symbol for a material. This symbol is bound to a material 
-                    at the time of instantiation. If the material attribute is not specified then the lighting 
+                    The material attribute declares a symbol for a material. This symbol is bound to a material
+                    at the time of instantiation. If the material attribute is not specified then the lighting
                     and shading results are application defined. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1679,7 +1679,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:annotation>
             <xs:documentation>
             The vertices element declares the attributes and identity of mesh-vertices. The vertices element
-            describes mesh-vertices in a mesh geometry. The mesh-vertices represent the position (identity) 
+            describes mesh-vertices in a mesh geometry. The mesh-vertices represent the position (identity)
             of the vertices comprising the mesh and other vertex attributes that are invariant to tessellation.
             </xs:documentation>
         </xs:annotation>
@@ -1703,7 +1703,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This 
+                    The id attribute is a text string containing the unique identifier of this element. This
                     value must be unique within the instance document. Required attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1722,7 +1722,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:annotation>
             <xs:documentation>
             The lookat element contains a position and orientation transformation suitable for aiming a camera.
-            The lookat element contains three mathematical vectors within it that describe: 
+            The lookat element contains three mathematical vectors within it that describe:
             1.    The position of the object;
             2.    The position of the interest point;
             3.    The direction that points up.
@@ -1734,7 +1734,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="sid" type="xs:NCName">
                         <xs:annotation>
                             <xs:documentation>
-                            The sid attribute is a text string value containing the sub-identifier of this element. 
+                            The sid attribute is a text string value containing the sub-identifier of this element.
                             This value must be unique within the scope of the parent element. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -1746,7 +1746,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="matrix">
         <xs:annotation>
             <xs:documentation>
-            Matrix transformations embody mathematical changes to points within a coordinate systems or the 
+            Matrix transformations embody mathematical changes to points within a coordinate systems or the
             coordinate system itself. The matrix element contains a 4-by-4 matrix of floating-point values.
             </xs:documentation>
         </xs:annotation>
@@ -1756,7 +1756,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="sid" type="xs:NCName">
                         <xs:annotation>
                             <xs:documentation>
-                            The sid attribute is a text string value containing the sub-identifier of this element. 
+                            The sid attribute is a text string value containing the sub-identifier of this element.
                             This value must be unique within the scope of the parent element. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -1777,7 +1777,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="sid" type="xs:NCName">
                         <xs:annotation>
                             <xs:documentation>
-                            The sid attribute is a text string value containing the sub-identifier of this element. 
+                            The sid attribute is a text string value containing the sub-identifier of this element.
                             This value must be unique within the scope of the parent element. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -1789,7 +1789,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="scale" type="TargetableFloat3">
         <xs:annotation>
             <xs:documentation>
-            The scale element contains a mathematical vector that represents the relative proportions of the 
+            The scale element contains a mathematical vector that represents the relative proportions of the
             X, Y and Z axes of a coordinated system.
             </xs:documentation>
         </xs:annotation>
@@ -1797,7 +1797,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="skew">
         <xs:annotation>
             <xs:documentation>
-            The skew element contains an angle and two mathematical vectors that represent the axis of 
+            The skew element contains an angle and two mathematical vectors that represent the axis of
             rotation and the axis of translation.
             </xs:documentation>
         </xs:annotation>
@@ -1807,7 +1807,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:attribute name="sid" type="xs:NCName">
                         <xs:annotation>
                             <xs:documentation>
-                            The sid attribute is a text string value containing the sub-identifier of this element. 
+                            The sid attribute is a text string value containing the sub-identifier of this element.
                             This value must be unique within the scope of the parent element. Optional attribute.
                             </xs:documentation>
                         </xs:annotation>
@@ -1819,7 +1819,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="translate" type="TargetableFloat3">
         <xs:annotation>
             <xs:documentation>
-            The translate element contains a mathematical vector that represents the distance along the 
+            The translate element contains a mathematical vector that represents the distance along the
             X, Y and Z-axes.
             </xs:documentation>
         </xs:annotation>
@@ -1828,9 +1828,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="image">
         <xs:annotation>
             <xs:documentation>
-            The image element declares the storage for the graphical representation of an object. 
-            The image element best describes raster image data, but can conceivably handle other 
-            forms of imagery. The image elements allows for specifying an external image file with 
+            The image element declares the storage for the graphical representation of an object.
+            The image element best describes raster image data, but can conceivably handle other
+            forms of imagery. The image elements allows for specifying an external image file with
             the init_from element or embed image data with the data element.
             </xs:documentation>
         </xs:annotation>
@@ -1847,7 +1847,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                     <xs:element name="data" type="ListOfHexBinary">
                         <xs:annotation>
                             <xs:documentation>
-                            The data child element contains a sequence of hexadecimal encoded  binary octets representing 
+                            The data child element contains a sequence of hexadecimal encoded  binary octets representing
                             the embedded image data.
                             </xs:documentation>
                         </xs:annotation>
@@ -1871,7 +1871,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This value 
+                    The id attribute is a text string containing the unique identifier of this element. This value
                     must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1893,7 +1893,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="height" type="uint">
                 <xs:annotation>
                     <xs:documentation>
-                    The height attribute is an integer value that indicates the height of the image in pixel 
+                    The height attribute is an integer value that indicates the height of the image in pixel
                     units. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1901,7 +1901,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="width" type="uint">
                 <xs:annotation>
                     <xs:documentation>
-                    The width attribute is an integer value that indicates the width of the image in pixel units. 
+                    The width attribute is an integer value that indicates the width of the image in pixel units.
                     Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1909,7 +1909,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="depth" type="uint" default="1">
                 <xs:annotation>
                     <xs:documentation>
-                    The depth attribute is an integer value that indicates the depth of the image in pixel units. 
+                    The depth attribute is an integer value that indicates the depth of the image in pixel units.
                     A 2-D image has a depth of 1, which is also the default value. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -1920,7 +1920,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:annotation>
             <xs:documentation>
             The light element declares a light source that illuminates the scene.
-            Light sources have many different properties and radiate light in many different patterns and 
+            Light sources have many different properties and radiate light in many different patterns and
             frequencies.
             </xs:documentation>
         </xs:annotation>
@@ -1936,7 +1936,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="technique_common">
                     <xs:annotation>
                         <xs:documentation>
-                        The technique_common element specifies the light information for the common profile which all 
+                        The technique_common element specifies the light information for the common profile which all
                         COLLADA implementations need to support.
                         </xs:documentation>
                     </xs:annotation>
@@ -1945,7 +1945,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="ambient">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    The ambient element declares the parameters required to describe an ambient light source.  
+                                    The ambient element declares the parameters required to describe an ambient light source.
                                     An ambient light is one that lights everything evenly, regardless of location or orientation.
                                     </xs:documentation>
                                 </xs:annotation>
@@ -1955,7 +1955,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                             <xs:annotation>
                                                 <xs:documentation>
                                                 The color element contains three floating point numbers specifying the color of the light.
-                                                The color element must occur exactly once.  
+                                                The color element must occur exactly once.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
@@ -1965,10 +1965,10 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="directional">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    The directional element declares the parameters required to describe a directional light source.  
-                                    A directional light is one that lights everything from the same direction, regardless of location.  
-                                    The light’s default direction vector in local coordinates is [0,0,-1], pointing down the -Z axis. 
-                                    The actual direction of the light is defined by the transform of the node where the light is 
+                                    The directional element declares the parameters required to describe a directional light source.
+                                    A directional light is one that lights everything from the same direction, regardless of location.
+                                    The light’s default direction vector in local coordinates is [0,0,-1], pointing down the -Z axis.
+                                    The actual direction of the light is defined by the transform of the node where the light is
                                     instantiated.
                                     </xs:documentation>
                                 </xs:annotation>
@@ -1978,7 +1978,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                             <xs:annotation>
                                                 <xs:documentation>
                                                 The color element contains three floating point numbers specifying the color of the light.
-                                                The color element must occur exactly once.  
+                                                The color element must occur exactly once.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
@@ -1988,9 +1988,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="point">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    The point element declares the parameters required to describe a point light source.  A point light 
-                                    source radiates light in all directions from a known location in space. The intensity of a point 
-                                    light source is attenuated as the distance to the light source increases. The position of the light 
+                                    The point element declares the parameters required to describe a point light source.  A point light
+                                    source radiates light in all directions from a known location in space. The intensity of a point
+                                    light source is attenuated as the distance to the light source increases. The position of the light
                                     is defined by the transform of the node in which it is instantiated.
                                     </xs:documentation>
                                 </xs:annotation>
@@ -2000,31 +2000,31 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                             <xs:annotation>
                                                 <xs:documentation>
                                                 The color element contains three floating point numbers specifying the color of the light.
-                                                The color element must occur exactly once.  
+                                                The color element must occur exactly once.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="constant_attenuation" type="TargetableFloat" default="1.0" minOccurs="0">
                                             <xs:annotation>
                                                 <xs:documentation>
-                                                The constant_attenuation is used to calculate the total attenuation of this light given a distance. 
-                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation. 
+                                                The constant_attenuation is used to calculate the total attenuation of this light given a distance.
+                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="linear_attenuation" type="TargetableFloat" default="0.0" minOccurs="0">
                                             <xs:annotation>
                                                 <xs:documentation>
-                                                The linear_attenuation is used to calculate the total attenuation of this light given a distance. 
-                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation. 
+                                                The linear_attenuation is used to calculate the total attenuation of this light given a distance.
+                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="quadratic_attenuation" type="TargetableFloat" default="0.0" minOccurs="0">
                                             <xs:annotation>
                                                 <xs:documentation>
-                                                The quadratic_attenuation is used to calculate the total attenuation of this light given a distance. 
-                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation. 
+                                                The quadratic_attenuation is used to calculate the total attenuation of this light given a distance.
+                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
@@ -2034,13 +2034,13 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="spot">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    The spot element declares the parameters required to describe a spot light source.  A spot light 
-                                    source radiates light in one direction from a known location in space. The light radiates from 
-                                    the spot light source in a cone shape. The intensity of the light is attenuated as the radiation 
-                                    angle increases away from the direction of the light source. The intensity of a spot light source 
-                                    is also attenuated as the distance to the light source increases. The position of the light is 
-                                    defined by the transform of the node in which it is instantiated. The light’s default direction 
-                                    vector in local coordinates is [0,0,-1], pointing down the -Z axis. The actual direction of the 
+                                    The spot element declares the parameters required to describe a spot light source.  A spot light
+                                    source radiates light in one direction from a known location in space. The light radiates from
+                                    the spot light source in a cone shape. The intensity of the light is attenuated as the radiation
+                                    angle increases away from the direction of the light source. The intensity of a spot light source
+                                    is also attenuated as the distance to the light source increases. The position of the light is
+                                    defined by the transform of the node in which it is instantiated. The light’s default direction
+                                    vector in local coordinates is [0,0,-1], pointing down the -Z axis. The actual direction of the
                                     light is defined by the transform of the node where the light is instantiated.
                                     </xs:documentation>
                                 </xs:annotation>
@@ -2050,31 +2050,31 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                             <xs:annotation>
                                                 <xs:documentation>
                                                 The color element contains three floating point numbers specifying the color of the light.
-                                                The color element must occur exactly once.  
+                                                The color element must occur exactly once.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="constant_attenuation" type="TargetableFloat" default="1.0" minOccurs="0">
                                             <xs:annotation>
                                                 <xs:documentation>
-                                                The constant_attenuation is used to calculate the total attenuation of this light given a distance. 
-                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation. 
+                                                The constant_attenuation is used to calculate the total attenuation of this light given a distance.
+                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="linear_attenuation" type="TargetableFloat" default="0.0" minOccurs="0">
                                             <xs:annotation>
                                                 <xs:documentation>
-                                                The linear_attenuation is used to calculate the total attenuation of this light given a distance. 
-                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation. 
+                                                The linear_attenuation is used to calculate the total attenuation of this light given a distance.
+                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="quadratic_attenuation" type="TargetableFloat" default="0.0" minOccurs="0">
                                             <xs:annotation>
                                                 <xs:documentation>
-                                                The quadratic_attenuation is used to calculate the total attenuation of this light given a distance. 
-                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation. 
+                                                The quadratic_attenuation is used to calculate the total attenuation of this light given a distance.
+                                                The equation used is A = constant_attenuation + Dist*linear_attenuation + Dist^2*quadratic_attenuation.
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
@@ -2116,7 +2116,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2163,7 +2163,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This value 
+                    The id attribute is a text string containing the unique identifier of this element. This value
                     must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2181,7 +2181,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="camera">
         <xs:annotation>
             <xs:documentation>
-            The camera element declares a view into the scene hierarchy or scene graph. The camera contains 
+            The camera element declares a view into the scene hierarchy or scene graph. The camera contains
             elements that describe the camera’s optics and imager.
             </xs:documentation>
         </xs:annotation>
@@ -2205,7 +2205,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="technique_common">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    The technique_common element specifies the optics information for the common profile 
+                                    The technique_common element specifies the optics information for the common profile
                                     which all COLLADA implementations need to support.
                                     </xs:documentation>
                                 </xs:annotation>
@@ -2224,7 +2224,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                             <xs:element name="xmag" type="TargetableFloat">
                                                                 <xs:annotation>
                                                                     <xs:documentation>
-                                                                    The xmag element contains a floating point number describing the horizontal 
+                                                                    The xmag element contains a floating point number describing the horizontal
                                                                     magnification of the view.
                                                                     </xs:documentation>
                                                                 </xs:annotation>
@@ -2233,7 +2233,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                                 <xs:element name="ymag" type="TargetableFloat">
                                                                     <xs:annotation>
                                                                         <xs:documentation>
-                                                                        The ymag element contains a floating point number describing the vertical 
+                                                                        The ymag element contains a floating point number describing the vertical
                                                                         magnification of the view.  It can also have a sid.
                                                                         </xs:documentation>
                                                                     </xs:annotation>
@@ -2241,8 +2241,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                                 <xs:element name="aspect_ratio" type="TargetableFloat">
                                                                     <xs:annotation>
                                                                         <xs:documentation>
-                                                                        The aspect_ratio element contains a floating point number describing the aspect ratio of 
-                                                                        the field of view. If the aspect_ratio element is not present the aspect ratio is to be 
+                                                                        The aspect_ratio element contains a floating point number describing the aspect ratio of
+                                                                        the field of view. If the aspect_ratio element is not present the aspect ratio is to be
                                                                         calculated from the xmag or ymag elements and the current viewport.
                                                                         </xs:documentation>
                                                                     </xs:annotation>
@@ -2257,7 +2257,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                     <xs:element name="znear" type="TargetableFloat">
                                                         <xs:annotation>
                                                             <xs:documentation>
-                                                            The znear element contains a floating point number that describes the distance to the near 
+                                                            The znear element contains a floating point number that describes the distance to the near
                                                             clipping plane. The znear element must occur exactly once.
                                                             </xs:documentation>
                                                         </xs:annotation>
@@ -2265,7 +2265,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                     <xs:element name="zfar" type="TargetableFloat">
                                                         <xs:annotation>
                                                             <xs:documentation>
-                                                            The zfar element contains a floating point number that describes the distance to the far 
+                                                            The zfar element contains a floating point number that describes the distance to the far
                                                             clipping plane. The zfar element must occur exactly once.
                                                             </xs:documentation>
                                                         </xs:annotation>
@@ -2301,8 +2301,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                                 <xs:element name="aspect_ratio" type="TargetableFloat">
                                                                     <xs:annotation>
                                                                         <xs:documentation>
-                                                                        The aspect_ratio element contains a floating point number describing the aspect ratio of the field 
-                                                                        of view. If the aspect_ratio element is not present the aspect ratio is to be calculated from the 
+                                                                        The aspect_ratio element contains a floating point number describing the aspect ratio of the field
+                                                                        of view. If the aspect_ratio element is not present the aspect ratio is to be calculated from the
                                                                         xfov or yfov elements and the current viewport.
                                                                         </xs:documentation>
                                                                     </xs:annotation>
@@ -2317,7 +2317,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                     <xs:element name="znear" type="TargetableFloat">
                                                         <xs:annotation>
                                                             <xs:documentation>
-                                                            The znear element contains a floating point number that describes the distance to the near 
+                                                            The znear element contains a floating point number that describes the distance to the near
                                                             clipping plane. The znear element must occur exactly once.
                                                             </xs:documentation>
                                                         </xs:annotation>
@@ -2325,7 +2325,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                     <xs:element name="zfar" type="TargetableFloat">
                                                         <xs:annotation>
                                                             <xs:documentation>
-                                                            The zfar element contains a floating point number that describes the distance to the far 
+                                                            The zfar element contains a floating point number that describes the distance to the far
                                                             clipping plane. The zfar element must occur exactly once.
                                                             </xs:documentation>
                                                         </xs:annotation>
@@ -2390,7 +2390,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This value 
+                    The id attribute is a text string containing the unique identifier of this element. This value
                     must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2408,8 +2408,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="animation">
         <xs:annotation>
             <xs:documentation>
-            The animation element categorizes the declaration of animation information. The animation 
-            hierarchy contains elements that describe the animation’s key-frame data and sampler functions, 
+            The animation element categorizes the declaration of animation information. The animation
+            hierarchy contains elements that describe the animation’s key-frame data and sampler functions,
             ordered in such a way to group together animations that should be executed together.
             </xs:documentation>
         </xs:annotation>
@@ -2476,7 +2476,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This value 
+                    The id attribute is a text string containing the unique identifier of this element. This value
                     must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2493,7 +2493,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="animation_clip">
         <xs:annotation>
             <xs:documentation>
-            The animation_clip element defines a section of the animation curves to be used together as 
+            The animation_clip element defines a section of the animation curves to be used together as
             an animation clip.
             </xs:documentation>
         </xs:annotation>
@@ -2524,7 +2524,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2539,10 +2539,10 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="start" type="xs:double" default="0.0">
                 <xs:annotation>
                     <xs:documentation>
-                    The start attribute is the time in seconds of the beginning of the clip.  This time is 
-                    the same as that used in the key-frame data and is used to determine which set of 
-                    key-frames will be included in the clip.  The start time does not specify when the clip 
-                    will be played.  If the time falls between two keyframes of a referenced animation, an 
+                    The start attribute is the time in seconds of the beginning of the clip.  This time is
+                    the same as that used in the key-frame data and is used to determine which set of
+                    key-frames will be included in the clip.  The start time does not specify when the clip
+                    will be played.  If the time falls between two keyframes of a referenced animation, an
                     interpolated value should be used.  The default value is 0.0.  Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2550,8 +2550,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="end" type="xs:double">
                 <xs:annotation>
                     <xs:documentation>
-                    The end attribute is the time in seconds of the end of the clip.  This is used in the 
-                    same way as the start time.  If end is not specified, the value is taken to be the end 
+                    The end attribute is the time in seconds of the end of the clip.  This is used in the
+                    same way as the start time.  If end is not specified, the value is taken to be the end
                     time of the longest animation.  Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2568,7 +2568,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="source" type="URIFragmentType" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The source attribute indicates the location of the sampler using a URL expression. 
+                    The source attribute indicates the location of the sampler using a URL expression.
                     The sampler must be declared within the same document. Required attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2576,8 +2576,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="target" type="xs:token" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The target attribute indicates the location of the element bound to the output of the sampler. 
-                    This text string is a path-name following a simple syntax described in Address Syntax. 
+                    The target attribute indicates the location of the element bound to the output of the sampler.
+                    This text string is a path-name following a simple syntax described in Address Syntax.
                     Required attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2587,8 +2587,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="sampler">
         <xs:annotation>
             <xs:documentation>
-            The sampler element declares an N-dimensional function used for animation. Animation function curves 
-            are represented by 1-D sampler elements in COLLADA. The sampler defines sampling points and how to 
+            The sampler element declares an N-dimensional function used for animation. Animation function curves
+            are represented by 1-D sampler elements in COLLADA. The sampler defines sampling points and how to
             interpolate between them.
             </xs:documentation>
         </xs:annotation>
@@ -2605,7 +2605,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This value 
+                    The id attribute is a text string containing the unique identifier of this element. This value
                     must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2656,7 +2656,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This value 
+                    The id attribute is a text string containing the unique identifier of this element. This value
                     must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2681,7 +2681,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="bind_shape_matrix" type="float4x4" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        This provides extra information about the position and orientation of the base mesh before binding. 
+                        This provides extra information about the position and orientation of the base mesh before binding.
                         If bind_shape_matrix is not specified then an identity matrix may be used as the bind_shape_matrix.
                         The bind_shape_matrix element may occur zero or one times.
                         </xs:documentation>
@@ -2697,7 +2697,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="joints">
                     <xs:annotation>
                         <xs:documentation>
-                        The joints element associates joint, or skeleton, nodes with attribute data.  
+                        The joints element associates joint, or skeleton, nodes with attribute data.
                         In COLLADA, this is specified by the inverse bind matrix of each joint (influence) in the skeleton.
                         </xs:documentation>
                     </xs:annotation>
@@ -2746,7 +2746,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="v" type="ListOfInts" minOccurs="0">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    The v element describes which bones and attributes are associated with each vertex.  An index 
+                                    The v element describes which bones and attributes are associated with each vertex.  An index
                                     of –1 into the array of joints refers to the bind shape.  Weights should be normalized before use.
                                     The v element must occur zero or one times.
                                     </xs:documentation>
@@ -2763,7 +2763,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="count" type="uint" use="required">
                             <xs:annotation>
                                 <xs:documentation>
-                                The count attribute describes the number of vertices in the base mesh. Required element. 
+                                The count attribute describes the number of vertices in the base mesh. Required element.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
@@ -2790,7 +2790,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="morph">
         <xs:annotation>
             <xs:documentation>
-            The morph element describes the data required to blend between sets of static meshes. Each 
+            The morph element describes the data required to blend between sets of static meshes. Each
             possible mesh that can be blended (a morph target) must be specified.
             </xs:documentation>
         </xs:annotation>
@@ -2806,7 +2806,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="targets">
                     <xs:annotation>
                         <xs:documentation>
-                        The targets element declares the morph targets, their weights and any user defined attributes 
+                        The targets element declares the morph targets, their weights and any user defined attributes
                         associated with them.
                         </xs:documentation>
                     </xs:annotation>
@@ -2840,7 +2840,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="method" type="MorphMethodType" default="NORMALIZED">
                 <xs:annotation>
                     <xs:documentation>
-                    The method attribute specifies the which blending technique to use. The accepted values are 
+                    The method attribute specifies the which blending technique to use. The accepted values are
                     NORMALIZED, and RELATIVE. The default value if not specified is NORMALIZED.  Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -2917,7 +2917,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="created" type="xs:dateTime">
                     <xs:annotation>
                         <xs:documentation>
-                        The created element contains the date and time that the parent element was created and is 
+                        The created element contains the date and time that the parent element was created and is
                         represented in an ISO 8601 format.  The created element may appear zero or one time.
                         </xs:documentation>
                     </xs:annotation>
@@ -2925,7 +2925,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="keywords" type="xs:string" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        The keywords element contains a list of words used as search criteria for the parent element. 
+                        The keywords element contains a list of words used as search criteria for the parent element.
                         The keywords element may appear zero or more times.
                         </xs:documentation>
                     </xs:annotation>
@@ -2933,7 +2933,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="modified" type="xs:dateTime">
                     <xs:annotation>
                         <xs:documentation>
-                        The modified element contains the date and time that the parent element was last modified and 
+                        The modified element contains the date and time that the parent element was last modified and
                         represented in an ISO 8601 format. The modified element may appear zero or one time.
                         </xs:documentation>
                     </xs:annotation>
@@ -2941,7 +2941,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="revision" type="xs:string" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        The revision element contains the revision information for the parent element. The revision 
+                        The revision element contains the revision information for the parent element. The revision
                         element may appear zero or one time.
                         </xs:documentation>
                     </xs:annotation>
@@ -2949,7 +2949,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="subject" type="xs:string" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        The subject element contains a description of the topical subject of the parent element. The 
+                        The subject element contains a description of the topical subject of the parent element. The
                         subject element may appear zero or one time.
                         </xs:documentation>
                     </xs:annotation>
@@ -2957,7 +2957,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="title" type="xs:string" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        The title element contains the title information for the parent element. The title element may 
+                        The title element contains the title information for the parent element. The title element may
                         appear zero or one time.
                         </xs:documentation>
                     </xs:annotation>
@@ -2965,8 +2965,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="unit" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        The unit element contains descriptive information about unit of measure. It has attributes for 
-                        the name of the unit and the measurement with respect to the meter. The unit element may appear 
+                        The unit element contains descriptive information about unit of measure. It has attributes for
+                        the name of the unit and the measurement with respect to the meter. The unit element may appear
                         zero or one time.
                         </xs:documentation>
                     </xs:annotation>
@@ -2974,7 +2974,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="meter" type="float" default="1.0">
                             <xs:annotation>
                                 <xs:documentation>
-                                The meter attribute specifies the measurement with respect to the meter. The default 
+                                The meter attribute specifies the measurement with respect to the meter. The default
                                 value for the meter attribute is “1.0”.
                                 </xs:documentation>
                             </xs:annotation>
@@ -2982,7 +2982,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="name" type="xs:NMTOKEN" default="meter">
                             <xs:annotation>
                                 <xs:documentation>
-                                The name attribute specifies the name of the unit. The default value for the name 
+                                The name attribute specifies the name of the unit. The default value for the name
                                 attribute is “meter”.
                                 </xs:documentation>
                             </xs:annotation>
@@ -2992,8 +2992,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="up_axis" type="UpAxisType" default="Y_UP" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        The up_axis element contains descriptive information about coordinate system of the geometric 
-                        data. All coordinates are right-handed by definition. This element specifies which axis is 
+                        The up_axis element contains descriptive information about coordinate system of the geometric
+                        data. All coordinates are right-handed by definition. This element specifies which axis is
                         considered up. The default is the Y-axis. The up_axis element may appear zero or one time.
                         </xs:documentation>
                     </xs:annotation>
@@ -3027,7 +3027,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This value 
+                    The id attribute is a text string containing the unique identifier of this element. This value
                     must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3042,7 +3042,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="type" type="xs:NMTOKEN">
                 <xs:annotation>
                     <xs:documentation>
-                    The type attribute indicates the type of the value data. This text string must be understood by 
+                    The type attribute indicates the type of the value data. This text string must be understood by
                     the application. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3053,9 +3053,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:annotation>
             <xs:appinfo>enable-xmlns</xs:appinfo>
             <xs:documentation>
-            The technique element declares the information used to process some portion of the content. Each 
-            technique conforms to an associated profile. Techniques generally act as a “switch”. If more than 
-            one is present for a particular portion of content, on import, one or the other is picked, but 
+            The technique element declares the information used to process some portion of the content. Each
+            technique conforms to an associated profile. Techniques generally act as a “switch”. If more than
+            one is present for a particular portion of content, on import, one or the other is picked, but
             usually not both. Selection should be based on which profile the importing application can support.
             Techniques contain application data and programs, making them assets that can be managed as a unit.
             </xs:documentation>
@@ -3067,7 +3067,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="profile" type="xs:NMTOKEN" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The profile attribute indicates the type of profile. This is a vendor defined character 
+                    The profile attribute indicates the type of profile. This is a vendor defined character
                     string that indicates the platform or capability target for the technique. Required attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3187,7 +3187,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3202,7 +3202,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. 
+                    The sid attribute is a text string value containing the sub-identifier of this element.
                     This value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3210,7 +3210,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="type" type="NodeType" default="NODE">
                 <xs:annotation>
                     <xs:documentation>
-                    The type attribute indicates the type of the node element. The default value is “NODE”. 
+                    The type attribute indicates the type of the node element. The default value is “NODE”.
                     Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3218,9 +3218,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="layer" type="ListOfNames">
                 <xs:annotation>
                     <xs:documentation>
-                    The layer attribute indicates the names of the layers to which this node belongs.  For example, 
-                    a value of “foreground glowing” indicates that this node belongs to both the ‘foreground’ layer 
-                    and the ‘glowing’ layer.  The default value is empty, indicating that the node doesn’t belong to 
+                    The layer attribute indicates the names of the layers to which this node belongs.  For example,
+                    a value of “foreground glowing” indicates that this node belongs to both the ‘foreground’ layer
+                    and the ‘glowing’ layer.  The default value is empty, indicating that the node doesn’t belong to
                     any layer.  Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3230,8 +3230,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="visual_scene">
         <xs:annotation>
             <xs:documentation>
-            The visual_scene element declares the base of the visual_scene hierarchy or scene graph. The 
-            scene contains elements that comprise much of the visual and transformational information 
+            The visual_scene element declares the base of the visual_scene hierarchy or scene graph. The
+            scene contains elements that comprise much of the visual and transformational information
             content as created by the authoring tools.
             </xs:documentation>
         </xs:annotation>
@@ -3254,7 +3254,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="evaluate_scene" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                        The evaluate_scene element declares information specifying a specific way to evaluate this 
+                        The evaluate_scene element declares information specifying a specific way to evaluate this
                         visual_scene. There may be any number of evaluate_scene elements.
                         </xs:documentation>
                     </xs:annotation>
@@ -3272,7 +3272,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                         <xs:element name="layer" type="xs:NCName" minOccurs="0" maxOccurs="unbounded">
                                             <xs:annotation>
                                                 <xs:documentation>
-                                                The layer element specifies which layer to render in this compositing step 
+                                                The layer element specifies which layer to render in this compositing step
                                                 while evaluating the scene. You may specify any number of layers.
                                                 </xs:documentation>
                                             </xs:annotation>
@@ -3280,7 +3280,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                         <xs:element ref="instance_effect" minOccurs="0">
                                             <xs:annotation>
                                                 <xs:documentation>
-                                                The instance_effect element specifies which effect to render in this compositing step 
+                                                The instance_effect element specifies which effect to render in this compositing step
                                                 while evaluating the scene.
                                                 </xs:documentation>
                                             </xs:annotation>
@@ -3289,7 +3289,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                     <xs:attribute name="camera_node" type="xs:anyURI" use="required">
                                         <xs:annotation>
                                             <xs:documentation>
-                                            The camera_node attribute refers to a node that contains a camera describing the viewpoint to 
+                                            The camera_node attribute refers to a node that contains a camera describing the viewpoint to
                                             render this compositing step from.
                                             </xs:documentation>
                                         </xs:annotation>
@@ -3317,7 +3317,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID" use="optional">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This 
+                    The id attribute is a text string containing the unique identifier of this element. This
                     value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3335,7 +3335,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="bind_material">
         <xs:annotation>
             <xs:documentation>
-            Bind a specific material to a piece of geometry, binding varying and uniform parameters at the 
+            Bind a specific material to a piece of geometry, binding varying and uniform parameters at the
             same time.
             </xs:documentation>
         </xs:annotation>
@@ -3351,7 +3351,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="technique_common">
                     <xs:annotation>
                         <xs:documentation>
-                        The technique_common element specifies the bind_material information for the common 
+                        The technique_common element specifies the bind_material information for the common
                         profile which all COLLADA implementations need to support.
                         </xs:documentation>
                     </xs:annotation>
@@ -3403,7 +3403,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="skeleton" type="xs:anyURI" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
-                        The skeleton element is used to indicate where a skin controller is to start to search for 
+                        The skeleton element is used to indicate where a skin controller is to start to search for
                         the joint nodes it needs.  This element is meaningless for morph controllers.
                         </xs:documentation>
                     </xs:annotation>
@@ -3411,7 +3411,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element ref="bind_material" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        Bind a specific material to a piece of geometry, binding varying and uniform parameters at the 
+                        Bind a specific material to a piece of geometry, binding varying and uniform parameters at the
                         same time.
                         </xs:documentation>
                     </xs:annotation>
@@ -3427,8 +3427,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="url" type="xs:anyURI" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The url attribute refers to resource. This may refer to a local resource using a relative 
-                    URL fragment identifier that begins with the “#” character. The url attribute may refer to an 
+                    The url attribute refers to resource. This may refer to a local resource using a relative
+                    URL fragment identifier that begins with the “#” character. The url attribute may refer to an
                     external resource using an absolute or relative URL.
                     </xs:documentation>
                 </xs:annotation>
@@ -3436,7 +3436,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. This 
+                    The sid attribute is a text string value containing the sub-identifier of this element. This
                     value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3512,8 +3512,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="url" type="xs:anyURI" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The url attribute refers to resource.  This may refer to a local resource using a relative URL 
-                    fragment identifier that begins with the “#” character. The url attribute may refer to an external 
+                    The url attribute refers to resource.  This may refer to a local resource using a relative URL
+                    fragment identifier that begins with the “#” character. The url attribute may refer to an external
                     resource using an absolute or relative URL.
                     </xs:documentation>
                 </xs:annotation>
@@ -3521,7 +3521,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. This 
+                    The sid attribute is a text string value containing the sub-identifier of this element. This
                     value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3553,7 +3553,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element ref="bind_material" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                        Bind a specific material to a piece of geometry, binding varying and uniform parameters at the 
+                        Bind a specific material to a piece of geometry, binding varying and uniform parameters at the
                         same time.
                         </xs:documentation>
                     </xs:annotation>
@@ -3569,8 +3569,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="url" type="xs:anyURI" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The url attribute refers to resource.  This may refer to a local resource using a relative URL 
-                    fragment identifier that begins with the “#” character. The url attribute may refer to an external 
+                    The url attribute refers to resource.  This may refer to a local resource using a relative URL
+                    fragment identifier that begins with the “#” character. The url attribute may refer to an external
                     resource using an absolute or relative URL.
                     </xs:documentation>
                 </xs:annotation>
@@ -3578,7 +3578,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. This 
+                    The sid attribute is a text string value containing the sub-identifier of this element. This
                     value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3624,8 +3624,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="target" type="xs:token" use="required">
                             <xs:annotation>
                                 <xs:documentation>
-                                The target attribute specifies the location of the value to bind to the specified semantic. 
-                                This text string is a path-name following a simple syntax described in the “Addressing Syntax” 
+                                The target attribute specifies the location of the value to bind to the specified semantic.
+                                This text string is a path-name following a simple syntax described in the “Addressing Syntax”
                                 section.
                                 </xs:documentation>
                             </xs:annotation>
@@ -3656,7 +3656,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="input_set" type="uint">
                             <xs:annotation>
                                 <xs:documentation>
-                                The input_set attribute specifies which input set to bind. 
+                                The input_set attribute specifies which input set to bind.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
@@ -3687,7 +3687,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. This 
+                    The sid attribute is a text string value containing the sub-identifier of this element. This
                     value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3711,7 +3711,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="instance_physics_material" type="InstanceWithExtra">
         <xs:annotation>
             <xs:documentation>
-            The instance_physics_material element declares the instantiation of a COLLADA physics_material 
+            The instance_physics_material element declares the instantiation of a COLLADA physics_material
             resource.
             </xs:documentation>
         </xs:annotation>
@@ -3756,8 +3756,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="url" type="xs:anyURI" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The url attribute refers to resource.  This may refer to a local resource using a relative URL 
-                    fragment identifier that begins with the “#” character. The url attribute may refer to an external 
+                    The url attribute refers to resource.  This may refer to a local resource using a relative URL
+                    fragment identifier that begins with the “#” character. The url attribute may refer to an external
                     resource using an absolute or relative URL.
                     </xs:documentation>
                 </xs:annotation>
@@ -3765,7 +3765,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. This 
+                    The sid attribute is a text string value containing the sub-identifier of this element. This
                     value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3780,8 +3780,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="parent" type="xs:anyURI">
                 <xs:annotation>
                     <xs:documentation>
-                    The parent attribute points to the id of a node in the visual scene. This allows a physics model 
-                    to be instantiated under a specific transform node, which will dictate the initial position and 
+                    The parent attribute points to the id of a node in the visual scene. This allows a physics model
+                    to be instantiated under a specific transform node, which will dictate the initial position and
                     orientation, and could be animated to influence kinematic rigid bodies.
                     </xs:documentation>
                 </xs:annotation>
@@ -3791,7 +3791,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="instance_rigid_body">
         <xs:annotation>
             <xs:documentation>
-            This element allows instancing a rigid_body within an instance_physics_model. 
+            This element allows instancing a rigid_body within an instance_physics_model.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType>
@@ -3799,7 +3799,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="technique_common">
                     <xs:annotation>
                         <xs:documentation>
-                        The technique_common element specifies the instance_rigid_body information for the common 
+                        The technique_common element specifies the instance_rigid_body information for the common
                         profile which all COLLADA implementations need to support.
                         </xs:documentation>
                     </xs:annotation>
@@ -3808,7 +3808,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="angular_velocity" type="float3" default="0.0 0.0 0.0" minOccurs="0">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    Specifies the initial angular velocity of the rigid_body instance in degrees per second 
+                                    Specifies the initial angular velocity of the rigid_body instance in degrees per second
                                     around each axis, in the form of an X-Y-Z Euler rotation.
                                     </xs:documentation>
                                 </xs:annotation>
@@ -3827,7 +3827,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                             <xs:attribute name="sid" type="xs:NCName">
                                                 <xs:annotation>
                                                     <xs:documentation>
-                                                    The sid attribute is a text string value containing the sub-identifier of this element. 
+                                                    The sid attribute is a text string value containing the sub-identifier of this element.
                                                     This value must be unique within the scope of the parent element. Optional attribute.
                                                     </xs:documentation>
                                                 </xs:annotation>
@@ -3926,7 +3926,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. This 
+                    The sid attribute is a text string value containing the sub-identifier of this element. This
                     value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -3941,7 +3941,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="target" type="xs:anyURI" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The target attribute indicates which node is influenced by this rigid_body instance. 
+                    The target attribute indicates which node is influenced by this rigid_body instance.
                     Required attribute
                     </xs:documentation>
                 </xs:annotation>
@@ -3951,7 +3951,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="instance_rigid_constraint">
         <xs:annotation>
             <xs:documentation>
-            This element allows instancing a rigid_constraint within an instance_physics_model. 
+            This element allows instancing a rigid_constraint within an instance_physics_model.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType>
@@ -3974,7 +3974,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. This 
+                    The sid attribute is a text string value containing the sub-identifier of this element. This
                     value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4022,7 +4022,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4069,7 +4069,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4116,7 +4116,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4163,7 +4163,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4210,7 +4210,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4257,7 +4257,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4304,7 +4304,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4351,7 +4351,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4398,7 +4398,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4445,7 +4445,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4492,7 +4492,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4539,7 +4539,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4586,7 +4586,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4633,7 +4633,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -4680,7 +4680,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -5367,7 +5367,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="sid" type="xs:NCName" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. 
+                    The sid attribute is a text string value containing the sub-identifier of this element.
                     This value must be unique within the scope of the parent element. Optional attribute.
                 </xs:documentation>
             </xs:annotation>
@@ -5375,8 +5375,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="url" type="xs:anyURI" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    The url attribute refers to resource.  This may refer to a local resource using a relative URL 
-                    fragment identifier that begins with the “#” character. The url attribute may refer to an external 
+                    The url attribute refers to resource.  This may refer to a local resource using a relative URL
+                    fragment identifier that begins with the “#” character. The url attribute may refer to an external
                     resource using an absolute or relative URL.
                 </xs:documentation>
             </xs:annotation>
@@ -5415,7 +5415,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="sid" type="xs:NCName" use="required">
             <xs:annotation>
                 <xs:documentation>
-                The sid attribute is a text string value containing the sub-identifier of this element. 
+                The sid attribute is a text string value containing the sub-identifier of this element.
                 This value must be unique within the scope of the parent element. Optional attribute.
                 </xs:documentation>
             </xs:annotation>
@@ -5435,7 +5435,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:attribute name="sid" type="xs:NCName" use="optional">
                     <xs:annotation>
                         <xs:documentation>
-                        The sid attribute is a text string value containing the sub-identifier of this element. 
+                        The sid attribute is a text string value containing the sub-identifier of this element.
                         This value must be unique within the scope of the parent element. Optional attribute.
                         </xs:documentation>
                     </xs:annotation>
@@ -5507,7 +5507,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -7296,7 +7296,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                                 <xs:attribute name="symbol" type="xs:NCName" use="required">
                                                                     <xs:annotation>
                                                                         <xs:documentation>
-                                                                        The identifier for a uniform input parameter to the shader (a formal function parameter or in-scope 
+                                                                        The identifier for a uniform input parameter to the shader (a formal function parameter or in-scope
                                                                         global) that will be bound to an external resource.
                                                                         </xs:documentation>
                                                                     </xs:annotation>
@@ -7319,7 +7319,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                     <xs:attribute name="sid" type="xs:NCName" use="optional">
                                         <xs:annotation>
                                             <xs:documentation>
-                                            The sid attribute is a text string value containing the sub-identifier of this element. 
+                                            The sid attribute is a text string value containing the sub-identifier of this element.
                                             This value must be unique within the scope of the parent element. Optional attribute.
                                             </xs:documentation>
                                         </xs:annotation>
@@ -7331,7 +7331,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="id" type="xs:ID">
                             <xs:annotation>
                                 <xs:documentation>
-                                The id attribute is a text string containing the unique identifier of this element. 
+                                The id attribute is a text string containing the unique identifier of this element.
                                 This value must be unique within the instance document. Optional attribute.
                                 </xs:documentation>
                             </xs:annotation>
@@ -7339,7 +7339,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="sid" type="xs:NCName" use="required">
                             <xs:annotation>
                                 <xs:documentation>
-                                The sid attribute is a text string value containing the sub-identifier of this element. 
+                                The sid attribute is a text string value containing the sub-identifier of this element.
                                 This value must be unique within the scope of the parent element. Optional attribute.
                                 </xs:documentation>
                             </xs:annotation>
@@ -7351,7 +7351,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID" use="optional">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -7428,7 +7428,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="sid" type="xs:NCName" use="required">
             <xs:annotation>
                 <xs:documentation>
-                The sid attribute is a text string value containing the sub-identifier of this element. 
+                The sid attribute is a text string value containing the sub-identifier of this element.
                 This value must be unique within the scope of the parent element. Optional attribute.
                 </xs:documentation>
             </xs:annotation>
@@ -7537,7 +7537,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="id" type="xs:ID">
                             <xs:annotation>
                                 <xs:documentation>
-                                The id attribute is a text string containing the unique identifier of this element. 
+                                The id attribute is a text string containing the unique identifier of this element.
                                 This value must be unique within the instance document. Optional attribute.
                                 </xs:documentation>
                             </xs:annotation>
@@ -7545,7 +7545,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="sid" type="xs:NCName" use="required">
                             <xs:annotation>
                                 <xs:documentation>
-                                The sid attribute is a text string value containing the sub-identifier of this element. 
+                                The sid attribute is a text string value containing the sub-identifier of this element.
                                 This value must be unique within the scope of the parent element. Optional attribute.
                                 </xs:documentation>
                             </xs:annotation>
@@ -7563,7 +7563,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID" use="optional">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -8712,7 +8712,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                                 <xs:attribute name="symbol" type="xs:NCName" use="required">
                                                                     <xs:annotation>
                                                                         <xs:documentation>
-                                                                        The identifier for a uniform input parameter to the shader (a formal function parameter or in-scope 
+                                                                        The identifier for a uniform input parameter to the shader (a formal function parameter or in-scope
                                                                         global) that will be bound to an external resource.
                                                                         </xs:documentation>
                                                                     </xs:annotation>
@@ -8735,7 +8735,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                     <xs:attribute name="sid" type="xs:NCName" use="optional">
                                         <xs:annotation>
                                             <xs:documentation>
-                                            The sid attribute is a text string value containing the sub-identifier of this element. 
+                                            The sid attribute is a text string value containing the sub-identifier of this element.
                                             This value must be unique within the scope of the parent element. Optional attribute.
                                             </xs:documentation>
                                         </xs:annotation>
@@ -8747,7 +8747,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="id" type="xs:ID">
                             <xs:annotation>
                                 <xs:documentation>
-                                The id attribute is a text string containing the unique identifier of this element. 
+                                The id attribute is a text string containing the unique identifier of this element.
                                 This value must be unique within the instance document. Optional attribute.
                                 </xs:documentation>
                             </xs:annotation>
@@ -8755,7 +8755,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="sid" type="xs:NCName" use="required">
                             <xs:annotation>
                                 <xs:documentation>
-                                The sid attribute is a text string value containing the sub-identifier of this element. 
+                                The sid attribute is a text string value containing the sub-identifier of this element.
                                 This value must be unique within the scope of the parent element. Optional attribute.
                                 </xs:documentation>
                             </xs:annotation>
@@ -8767,7 +8767,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID" use="optional">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -9064,7 +9064,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="sid" type="xs:NCName">
             <xs:annotation>
                 <xs:documentation>
-                The sid attribute is a text string value containing the sub-identifier of this element. 
+                The sid attribute is a text string value containing the sub-identifier of this element.
                 This value must be unique within the scope of the parent element. Optional attribute.
                 </xs:documentation>
             </xs:annotation>
@@ -9084,7 +9084,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="sid" type="xs:NCName">
             <xs:annotation>
                 <xs:documentation>
-                The sid attribute is a text string value containing the sub-identifier of this element. 
+                The sid attribute is a text string value containing the sub-identifier of this element.
                 This value must be unique within the scope of the parent element. Optional attribute.
                 </xs:documentation>
             </xs:annotation>
@@ -9131,7 +9131,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="sid" type="xs:NCName">
             <xs:annotation>
                 <xs:documentation>
-                The sid attribute is a text string value containing the sub-identifier of this element. 
+                The sid attribute is a text string value containing the sub-identifier of this element.
                 This value must be unique within the scope of the parent element. Optional attribute.
                 </xs:documentation>
             </xs:annotation>
@@ -9772,7 +9772,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
         <xs:attribute name="sid" type="xs:NCName" use="required">
             <xs:annotation>
                 <xs:documentation>
-                The sid attribute is a text string value containing the sub-identifier of this element. 
+                The sid attribute is a text string value containing the sub-identifier of this element.
                 This value must be unique within the scope of the parent element.
                 </xs:documentation>
             </xs:annotation>
@@ -9841,7 +9841,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                     <xs:attribute name="sid" type="xs:NCName" use="optional">
                                         <xs:annotation>
                                             <xs:documentation>
-                                            The sid attribute is a text string value containing the sub-identifier of this element. 
+                                            The sid attribute is a text string value containing the sub-identifier of this element.
                                             This value must be unique within the scope of the parent element. Optional attribute.
                                             </xs:documentation>
                                         </xs:annotation>
@@ -9854,7 +9854,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="sid" type="xs:NCName" use="required">
                             <xs:annotation>
                                 <xs:documentation>
-                                The sid attribute is a text string value containing the sub-identifier of this element. 
+                                The sid attribute is a text string value containing the sub-identifier of this element.
                                 This value must be unique within the scope of the parent element.
                                 </xs:documentation>
                             </xs:annotation>
@@ -9866,7 +9866,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID" use="optional">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -10014,7 +10014,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="radius1" type="float2">
                     <xs:annotation>
                         <xs:documentation>
-                        Two float values that represent the radii of the tapered cylinder at the positive (height/2) 
+                        Two float values that represent the radii of the tapered cylinder at the positive (height/2)
                         Y value. Both ends of the tapered cylinder may be elliptical.
                         </xs:documentation>
                     </xs:annotation>
@@ -10022,7 +10022,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="radius2" type="float2">
                     <xs:annotation>
                         <xs:documentation>
-                        Two float values that represent the radii of the tapered cylinder at the negative (height/2) 
+                        Two float values that represent the radii of the tapered cylinder at the negative (height/2)
                         Y value.Both ends of the tapered cylinder may be elliptical.
                         </xs:documentation>
                     </xs:annotation>
@@ -10048,7 +10048,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="height" type="float">
                     <xs:annotation>
                         <xs:documentation>
-                        A float value that represents the length of the line segment connecting the centers 
+                        A float value that represents the length of the line segment connecting the centers
                         of the capping hemispheres.
                         </xs:documentation>
                     </xs:annotation>
@@ -10081,7 +10081,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="height" type="float">
                     <xs:annotation>
                         <xs:documentation>
-                        A float value that represents the length of the line segment connecting the centers of the 
+                        A float value that represents the length of the line segment connecting the centers of the
                         capping hemispheres.
                         </xs:documentation>
                     </xs:annotation>
@@ -10089,7 +10089,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="radius1" type="float2">
                     <xs:annotation>
                         <xs:documentation>
-                        Two float values that represent the radii of the tapered capsule at the positive (height/2) 
+                        Two float values that represent the radii of the tapered capsule at the positive (height/2)
                         Y value.Both ends of the tapered capsule may be elliptical.
                         </xs:documentation>
                     </xs:annotation>
@@ -10097,7 +10097,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="radius2" type="float2">
                     <xs:annotation>
                         <xs:documentation>
-                        Two float values that represent the radii of the tapered capsule at the negative (height/2) 
+                        Two float values that represent the radii of the tapered capsule at the negative (height/2)
                         Y value.Both ends of the tapered capsule may be elliptical.
                         </xs:documentation>
                     </xs:annotation>
@@ -10115,9 +10115,9 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="convex_mesh">
         <xs:annotation>
             <xs:documentation>
-            The definition of the convex_mesh element is identical to the mesh element with the exception that 
-            instead of a complete description (source, vertices, polygons etc.), it may simply point to another 
-            geometry to derive its shape. The latter case means that the convex hull of that geometry should 
+            The definition of the convex_mesh element is identical to the mesh element with the exception that
+            instead of a complete description (source, vertices, polygons etc.), it may simply point to another
+            geometry to derive its shape. The latter case means that the convex hull of that geometry should
             be computed and is indicated by the optional “convex_hull_of” attribute.
             </xs:documentation>
         </xs:annotation>
@@ -10145,7 +10145,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="convex_hull_of" type="xs:anyURI">
                 <xs:annotation>
                     <xs:documentation>
-                    The convex_hull_of attribute is a URI string of geometry to compute the convex hull of. 
+                    The convex_hull_of attribute is a URI string of geometry to compute the convex hull of.
                     Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -10186,7 +10186,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. This value 
+                    The id attribute is a text string containing the unique identifier of this element. This value
                     must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -10203,7 +10203,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="physics_material">
         <xs:annotation>
             <xs:documentation>
-            This element defines the physical properties of an object. It contains a technique/profile with 
+            This element defines the physical properties of an object. It contains a technique/profile with
             parameters. The COMMON profile defines the built-in names, such as static_friction.
             </xs:documentation>
         </xs:annotation>
@@ -10219,7 +10219,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="technique_common">
                     <xs:annotation>
                         <xs:documentation>
-                        The technique_common element specifies the physics_material information for the common profile 
+                        The technique_common element specifies the physics_material information for the common profile
                         which all COLLADA implementations need to support.
                         </xs:documentation>
                     </xs:annotation>
@@ -10267,7 +10267,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -10308,7 +10308,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="technique_common">
                     <xs:annotation>
                         <xs:documentation>
-                        The technique_common element specifies the physics_scene information for the common profile 
+                        The technique_common element specifies the physics_scene information for the common profile
                         which all COLLADA implementations need to support.
                         </xs:documentation>
                     </xs:annotation>
@@ -10349,7 +10349,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -10372,8 +10372,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="rigid_body">
         <xs:annotation>
             <xs:documentation>
-            This element allows for describing simulated bodies that do not deform. These bodies may or may 
-            not be connected by constraints (hinge, ball-joint etc.).  Rigid-bodies, constraints etc. are 
+            This element allows for describing simulated bodies that do not deform. These bodies may or may
+            not be connected by constraints (hinge, ball-joint etc.).  Rigid-bodies, constraints etc. are
             encapsulated in physics_model elements to allow for instantiating complex models.
             </xs:documentation>
         </xs:annotation>
@@ -10382,7 +10382,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="technique_common">
                     <xs:annotation>
                         <xs:documentation>
-                        The technique_common element specifies the rigid_body information for the common profile which all 
+                        The technique_common element specifies the rigid_body information for the common profile which all
                         COLLADA implementations need to support.
                         </xs:documentation>
                     </xs:annotation>
@@ -10400,7 +10400,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                             <xs:attribute name="sid" type="xs:NCName">
                                                 <xs:annotation>
                                                     <xs:documentation>
-                                                    The sid attribute is a text string value containing the sub-identifier of this element. 
+                                                    The sid attribute is a text string value containing the sub-identifier of this element.
                                                     This value must be unique within the scope of the parent element. Optional attribute.
                                                     </xs:documentation>
                                                 </xs:annotation>
@@ -10419,8 +10419,8 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="mass_frame" minOccurs="0">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    Defines the center and orientation of mass of the rigid-body relative to the local origin of the 
-                                    “root” shape.This makes the off-diagonal elements of the inertia tensor (products of inertia) all 
+                                    Defines the center and orientation of mass of the rigid-body relative to the local origin of the
+                                    “root” shape.This makes the off-diagonal elements of the inertia tensor (products of inertia) all
                                     0 and allows us to just store the diagonal elements (moments of inertia).
                                     </xs:documentation>
                                 </xs:annotation>
@@ -10434,7 +10434,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="inertia" type="TargetableFloat3" minOccurs="0">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    float3 – The diagonal elements of the inertia tensor (moments of inertia), which is represented 
+                                    float3 – The diagonal elements of the inertia tensor (moments of inertia), which is represented
                                     in the local frame of the center of mass. See above.
                                     </xs:documentation>
                                 </xs:annotation>
@@ -10475,7 +10475,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                         <xs:attribute name="sid" type="xs:NCName">
                                                             <xs:annotation>
                                                                 <xs:documentation>
-                                                                The sid attribute is a text string value containing the sub-identifier of this element. 
+                                                                The sid attribute is a text string value containing the sub-identifier of this element.
                                                                 This value must be unique within the scope of the parent element. Optional attribute.
                                                                 </xs:documentation>
                                                             </xs:annotation>
@@ -10619,7 +10619,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. This 
+                    The sid attribute is a text string value containing the sub-identifier of this element. This
                     value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -10636,7 +10636,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="rigid_constraint">
         <xs:annotation>
             <xs:documentation>
-            This element allows for connecting components, such as rigid_body into complex physics models 
+            This element allows for connecting components, such as rigid_body into complex physics models
             with moveable parts.
             </xs:documentation>
         </xs:annotation>
@@ -10675,7 +10675,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                         <xs:attribute name="rigid_body" type="xs:anyURI">
                             <xs:annotation>
                                 <xs:documentation>
-                                The “rigid_body” attribute is a relative reference to a rigid-body within the same 
+                                The “rigid_body” attribute is a relative reference to a rigid-body within the same
                                 physics_model.
                                 </xs:documentation>
                             </xs:annotation>
@@ -10724,7 +10724,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                 <xs:element name="technique_common">
                     <xs:annotation>
                         <xs:documentation>
-                        The technique_common element specifies the rigid_constraint information for the common profile 
+                        The technique_common element specifies the rigid_constraint information for the common profile
                         which all COLLADA implementations need to support.
                         </xs:documentation>
                     </xs:annotation>
@@ -10742,7 +10742,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                             <xs:attribute name="sid" type="xs:NCName">
                                                 <xs:annotation>
                                                     <xs:documentation>
-                                                    The sid attribute is a text string value containing the sub-identifier of this element. 
+                                                    The sid attribute is a text string value containing the sub-identifier of this element.
                                                     This value must be unique within the scope of the parent element. Optional attribute.
                                                     </xs:documentation>
                                                 </xs:annotation>
@@ -10763,7 +10763,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                             <xs:attribute name="sid" type="xs:NCName">
                                                 <xs:annotation>
                                                     <xs:documentation>
-                                                    The sid attribute is a text string value containing the sub-identifier of this element. 
+                                                    The sid attribute is a text string value containing the sub-identifier of this element.
                                                     This value must be unique within the scope of the parent element. Optional attribute.
                                                     </xs:documentation>
                                                 </xs:annotation>
@@ -10775,7 +10775,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="limits" minOccurs="0">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    The limits element provides a flexible way to specify the constraint limits (degrees of freedom 
+                                    The limits element provides a flexible way to specify the constraint limits (degrees of freedom
                                     and ranges).
                                     </xs:documentation>
                                 </xs:annotation>
@@ -10785,7 +10785,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                             <xs:annotation>
                                                 <xs:documentation>
                                                 The swing_cone_and_twist element describes the angular limits along each rotation axis in degrees.
-                                                The the X and Y limits describe a “swing cone” and the Z limits describe the “twist angle” range 
+                                                The the X and Y limits describe a “swing cone” and the Z limits describe the “twist angle” range
                                                 </xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
@@ -10838,7 +10838,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                             <xs:element name="spring" minOccurs="0">
                                 <xs:annotation>
                                     <xs:documentation>
-                                    Spring, based on distance (“LINEAR”) or angle (“ANGULAR”). 
+                                    Spring, based on distance (“LINEAR”) or angle (“ANGULAR”).
                                     </xs:documentation>
                                 </xs:annotation>
                                 <xs:complexType>
@@ -10854,7 +10854,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                     <xs:element name="stiffness" type="TargetableFloat" default="1.0" minOccurs="0">
                                                         <xs:annotation>
                                                             <xs:documentation>
-                                                            The stiffness (also called spring coefficient) has units of force/angle in degrees. 
+                                                            The stiffness (also called spring coefficient) has units of force/angle in degrees.
                                                             </xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
@@ -10886,7 +10886,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
                                                     <xs:element name="stiffness" type="TargetableFloat" default="1.0" minOccurs="0">
                                                         <xs:annotation>
                                                             <xs:documentation>
-                                                            The stiffness (also called spring coefficient) has units of force/distance. 
+                                                            The stiffness (also called spring coefficient) has units of force/distance.
                                                             </xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
@@ -10931,7 +10931,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="sid" type="xs:NCName" use="required">
                 <xs:annotation>
                     <xs:documentation>
-                    The sid attribute is a text string value containing the sub-identifier of this element. 
+                    The sid attribute is a text string value containing the sub-identifier of this element.
                     This value must be unique within the scope of the parent element. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -10948,7 +10948,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
     <xs:element name="physics_model">
         <xs:annotation>
             <xs:documentation>
-            This element allows for building complex combinations of rigid-bodies and constraints that 
+            This element allows for building complex combinations of rigid-bodies and constraints that
             may be instantiated multiple times.
             </xs:documentation>
         </xs:annotation>
@@ -10993,7 +10993,7 @@ COLLADA_SCHEMA_1_4_1 = """<?xml version="1.0" encoding="utf-8"?>
             <xs:attribute name="id" type="xs:ID">
                 <xs:annotation>
                     <xs:documentation>
-                    The id attribute is a text string containing the unique identifier of this element. 
+                    The id attribute is a text string containing the unique identifier of this element.
                     This value must be unique within the instance document. Optional attribute.
                     </xs:documentation>
                 </xs:annotation>
@@ -11074,7 +11074,7 @@ XML_XSD = """<?xml version='1.0'?>
    http://www.w3.org/TR/REC-xml for information about this namespace.
 
     This schema document describes the XML namespace, in a form
-    suitable for import by other schema documents.  
+    suitable for import by other schema documents.
 
     Note that local names in this namespace are intended to be defined
     only by the World Wide Web Consortium or its subgroups.  The
@@ -11092,16 +11092,16 @@ XML_XSD = """<?xml version='1.0'?>
          is a language code for the natural language of the content of
          any element; its value is inherited.  This name is reserved
          by virtue of its definition in the XML specification.
-  
+
     space (as an attribute name): denotes an attribute whose
          value is a keyword indicating what whitespace processing
          discipline is intended for the content of the element; its
          value is inherited.  This name is reserved by virtue of its
          definition in the XML specification.
 
-    Father (in any context at all): denotes Jon Bosak, the chair of 
-         the original XML Working Group.  This name is reserved by 
-         the following decision of the W3C XML Plenary and 
+    Father (in any context at all): denotes Jon Bosak, the chair of
+         the original XML Working Group.  This name is reserved by
+         the following decision of the W3C XML Plenary and
          XML Coordination groups:
 
              In appreciation for his vision, leadership and dedication
@@ -11130,7 +11130,7 @@ XML_XSD = """<?xml version='1.0'?>
         &lt;type . . .>
          . . .
          &lt;attributeGroup ref="xml:specialAttrs"/>
- 
+
          will define a type which will schema-validate an instance
          element with any of those attributes</xs:documentation>
  </xs:annotation>
@@ -11197,20 +11197,24 @@ class ColladaResolver(lxml.etree.Resolver):
         else:
             return None
 
+
 class ColladaValidator(object):
     """Validates a collada lxml document"""
-    
+
     def __init__(self):
         """Initializes the validator"""
         self.COLLADA_SCHEMA_1_4_1_DOC = None
         self._COLLADA_SCHEMA_1_4_1_INSTANCE = None
-    
+
     def _getColladaSchemaInstance(self):
         if self._COLLADA_SCHEMA_1_4_1_INSTANCE is None:
             self._parser = lxml.etree.XMLParser()
             self._parser.resolvers.add(ColladaResolver())
-            self.COLLADA_SCHEMA_1_4_1_DOC = lxml.etree.parse(StringIO.StringIO(COLLADA_SCHEMA_1_4_1), self._parser)
-            self._COLLADA_SCHEMA_1_4_1_INSTANCE = lxml.etree.XMLSchema(self.COLLADA_SCHEMA_1_4_1_DOC)
+            self.COLLADA_SCHEMA_1_4_1_DOC = lxml.etree.parse(
+                    BytesIO(bytes(COLLADA_SCHEMA_1_4_1, encoding='utf-8')),
+                    self._parser)
+            self._COLLADA_SCHEMA_1_4_1_INSTANCE = lxml.etree.XMLSchema(
+                    self.COLLADA_SCHEMA_1_4_1_DOC)
         return self._COLLADA_SCHEMA_1_4_1_INSTANCE
 
     COLLADA_SCHEMA_1_4_1_INSTANCE = property(_getColladaSchemaInstance)
@@ -11219,3 +11223,4 @@ class ColladaValidator(object):
     def validate(self, *args, **kwargs):
         """A wrapper for lxml.XMLSchema.validate"""
         return self.COLLADA_SCHEMA_1_4_1_INSTANCE.validate(*args, **kwargs)
+

--- a/collada/tests/test_asset.py
+++ b/collada/tests/test_asset.py
@@ -1,13 +1,15 @@
-import unittest2
-import collada
-from lxml.etree import fromstring, tostring
 import datetime
+from lxml.etree import fromstring, tostring
 
-class TestAsset(unittest2.TestCase):
+import collada
+from collada.util import unittest
+
+
+class TestAsset(unittest.TestCase):
 
     def setUp(self):
         self.dummy = collada.Collada(validate_output=True)
-        
+
     def test_asset_contributor(self):
         contributor = collada.asset.Contributor()
         self.assertIsNone(contributor.author)
@@ -15,7 +17,7 @@ class TestAsset(unittest2.TestCase):
         self.assertIsNone(contributor.comments)
         self.assertIsNone(contributor.copyright)
         self.assertIsNone(contributor.source_data)
-        
+
         contributor.save()
         contributor = collada.asset.Contributor.load(self.dummy, {}, fromstring(tostring(contributor.xmlnode)))
         self.assertIsNone(contributor.author)
@@ -23,13 +25,13 @@ class TestAsset(unittest2.TestCase):
         self.assertIsNone(contributor.comments)
         self.assertIsNone(contributor.copyright)
         self.assertIsNone(contributor.source_data)
-                
+
         contributor.author = "author1"
         contributor.authoring_tool = "tool2"
         contributor.comments = "comments3"
         contributor.copyright = "copyright4"
         contributor.source_data = "data5"
-        
+
         contributor.save()
         contributor = collada.asset.Contributor.load(self.dummy, {}, fromstring(tostring(contributor.xmlnode)))
         self.assertEqual(contributor.author, "author1")
@@ -37,10 +39,10 @@ class TestAsset(unittest2.TestCase):
         self.assertEqual(contributor.comments, "comments3")
         self.assertEqual(contributor.copyright, "copyright4")
         self.assertEqual(contributor.source_data, "data5")
-        
+
     def test_asset(self):
         asset = collada.asset.Asset()
-        
+
         self.assertIsNone(asset.title)
         self.assertIsNone(asset.subject)
         self.assertIsNone(asset.revision)
@@ -51,10 +53,10 @@ class TestAsset(unittest2.TestCase):
         self.assertEqual(asset.upaxis, collada.asset.UP_AXIS.Y_UP)
         self.assertIsInstance(asset.created, datetime.datetime)
         self.assertIsInstance(asset.modified, datetime.datetime)
-        
+
         asset.save()
         asset = collada.asset.Asset.load(self.dummy, {}, fromstring(tostring(asset.xmlnode)))
-        
+
         self.assertIsNone(asset.title)
         self.assertIsNone(asset.subject)
         self.assertIsNone(asset.revision)
@@ -65,7 +67,7 @@ class TestAsset(unittest2.TestCase):
         self.assertEqual(asset.upaxis, collada.asset.UP_AXIS.Y_UP)
         self.assertIsInstance(asset.created, datetime.datetime)
         self.assertIsInstance(asset.modified, datetime.datetime)
-        
+
         asset.title = 'title1'
         asset.subject = 'subject2'
         asset.revision = 'revision3'
@@ -80,7 +82,7 @@ class TestAsset(unittest2.TestCase):
         asset.created = time1
         time2 = datetime.datetime.now() + datetime.timedelta(hours=5)
         asset.modified = time2
-        
+
         asset.save()
         asset = collada.asset.Asset.load(self.dummy, {}, fromstring(tostring(asset.xmlnode)))
         self.assertEqual(asset.title, 'title1')
@@ -93,6 +95,6 @@ class TestAsset(unittest2.TestCase):
         self.assertEqual(asset.created, time1)
         self.assertEqual(asset.modified, time2)
         self.assertEqual(len(asset.contributors), 2)
-        
+
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/collada/tests/test_camera.py
+++ b/collada/tests/test_camera.py
@@ -1,61 +1,64 @@
-import unittest2
-import collada
 from lxml.etree import fromstring, tostring
 
-class TestCamera(unittest2.TestCase):
+import collada
+from collada.common import DaeMalformedError
+from collada.util import unittest
+
+
+class TestCamera(unittest.TestCase):
 
     def setUp(self):
         self.dummy = collada.Collada(validate_output=True)
 
     def test_perspective_camera_xfov_yfov_aspect_ratio(self):
         #test invalid xfov,yfov,aspect_ratio combinations
-        with self.assertRaises(collada.DaeMalformedError):
+        with self.assertRaises(DaeMalformedError):
             cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=None, yfov=None, aspect_ratio=None)
-        with self.assertRaises(collada.DaeMalformedError):
+        with self.assertRaises(DaeMalformedError):
             cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=0.2, yfov=30, aspect_ratio=50)
-        with self.assertRaises(collada.DaeMalformedError):
+        with self.assertRaises(DaeMalformedError):
             cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=None, yfov=None, aspect_ratio=50)
-            
+
         #xfov alone
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=30, yfov=None, aspect_ratio=None)
         self.assertEqual(cam.xfov, 30)
         self.assertIsNone(cam.yfov)
         self.assertIsNone(cam.aspect_ratio)
-        
+
         #yfov alone
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=None, yfov=50, aspect_ratio=None)
         self.assertIsNone(cam.xfov)
         self.assertEqual(cam.yfov, 50)
         self.assertIsNone(cam.aspect_ratio)
-        
+
         #xfov + yfov
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=30, yfov=50, aspect_ratio=None)
         self.assertEqual(cam.xfov, 30)
         self.assertEqual(cam.yfov, 50)
         self.assertIsNone(cam.aspect_ratio)
-        
+
         #xfov + aspect_ratio
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=30, yfov=None, aspect_ratio=1)
         self.assertEqual(cam.xfov, 30)
         self.assertIsNone(cam.yfov)
         self.assertEqual(cam.aspect_ratio, 1)
-        
+
         #yfov + aspect_ratio
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=None, yfov=50, aspect_ratio=1)
         self.assertIsNone(cam.xfov)
         self.assertEqual(cam.yfov, 50)
         self.assertEqual(cam.aspect_ratio, 1)
-        
+
     def test_perspective_camera_saving(self):
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=30)
-        
+
         self.assertEqual(cam.id, "mycam")
         self.assertEqual(cam.znear, 1)
         self.assertEqual(cam.zfar, 1000)
         self.assertEqual(cam.xfov, 30)
         self.assertEqual(cam.yfov, None)
         self.assertEqual(cam.aspect_ratio, None)
-        
+
         cam.save()
         self.assertEqual(cam.id, "mycam")
         self.assertEqual(cam.znear, 1)
@@ -63,7 +66,7 @@ class TestCamera(unittest2.TestCase):
         self.assertEqual(cam.xfov, 30)
         self.assertEqual(cam.yfov, None)
         self.assertEqual(cam.aspect_ratio, None)
-        
+
         cam = collada.camera.PerspectiveCamera.load(self.dummy, {}, fromstring(tostring(cam.xmlnode)))
         self.assertEqual(cam.id, "mycam")
         self.assertEqual(cam.znear, 1)
@@ -71,7 +74,7 @@ class TestCamera(unittest2.TestCase):
         self.assertEqual(cam.xfov, 30)
         self.assertEqual(cam.yfov, None)
         self.assertEqual(cam.aspect_ratio, None)
-        
+
         cam.id = "yourcam"
         cam.znear = 5
         cam.zfar = 500
@@ -86,44 +89,44 @@ class TestCamera(unittest2.TestCase):
         self.assertEqual(cam.xfov, None)
         self.assertEqual(cam.yfov, 50)
         self.assertEqual(cam.aspect_ratio, 1.3)
-        
+
         cam.xfov = 20
-        with self.assertRaises(collada.DaeMalformedError):
+        with self.assertRaises(DaeMalformedError):
             cam.save()
 
     def test_orthographic_camera_xmag_ymag_aspect_ratio(self):
         #test invalid xmag,ymag,aspect_ratio combinations
-        with self.assertRaises(collada.DaeMalformedError):
+        with self.assertRaises(DaeMalformedError):
             cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=None, ymag=None, aspect_ratio=None)
-        with self.assertRaises(collada.DaeMalformedError):
+        with self.assertRaises(DaeMalformedError):
             cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=0.2, ymag=30, aspect_ratio=50)
-        with self.assertRaises(collada.DaeMalformedError):
+        with self.assertRaises(DaeMalformedError):
             cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=None, ymag=None, aspect_ratio=50)
-            
+
         #xmag alone
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=30, ymag=None, aspect_ratio=None)
         self.assertEqual(cam.xmag, 30)
         self.assertIsNone(cam.ymag)
         self.assertIsNone(cam.aspect_ratio)
-        
+
         #ymag alone
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=None, ymag=50, aspect_ratio=None)
         self.assertIsNone(cam.xmag)
         self.assertEqual(cam.ymag, 50)
         self.assertIsNone(cam.aspect_ratio)
-        
+
         #xmag + ymag
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=30, ymag=50, aspect_ratio=None)
         self.assertEqual(cam.xmag, 30)
         self.assertEqual(cam.ymag, 50)
         self.assertIsNone(cam.aspect_ratio)
-        
+
         #xmag + aspect_ratio
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=30, ymag=None, aspect_ratio=1)
         self.assertEqual(cam.xmag, 30)
         self.assertIsNone(cam.ymag)
         self.assertEqual(cam.aspect_ratio, 1)
-        
+
         #ymag + aspect_ratio
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=None, ymag=50, aspect_ratio=1)
         self.assertIsNone(cam.xmag)
@@ -132,14 +135,14 @@ class TestCamera(unittest2.TestCase):
 
     def test_orthographic_camera_saving(self):
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=30)
-        
+
         self.assertEqual(cam.id, "mycam")
         self.assertEqual(cam.znear, 1)
         self.assertEqual(cam.zfar, 1000)
         self.assertEqual(cam.xmag, 30)
         self.assertEqual(cam.ymag, None)
         self.assertEqual(cam.aspect_ratio, None)
-        
+
         cam.save()
         self.assertEqual(cam.id, "mycam")
         self.assertEqual(cam.znear, 1)
@@ -147,7 +150,7 @@ class TestCamera(unittest2.TestCase):
         self.assertEqual(cam.xmag, 30)
         self.assertEqual(cam.ymag, None)
         self.assertEqual(cam.aspect_ratio, None)
-        
+
         cam = collada.camera.OrthographicCamera.load(self.dummy, {}, fromstring(tostring(cam.xmlnode)))
         self.assertEqual(cam.id, "mycam")
         self.assertEqual(cam.znear, 1)
@@ -155,7 +158,7 @@ class TestCamera(unittest2.TestCase):
         self.assertEqual(cam.xmag, 30)
         self.assertEqual(cam.ymag, None)
         self.assertEqual(cam.aspect_ratio, None)
-        
+
         cam.id = "yourcam"
         cam.znear = 5
         cam.zfar = 500
@@ -170,10 +173,10 @@ class TestCamera(unittest2.TestCase):
         self.assertEqual(cam.xmag, None)
         self.assertEqual(cam.ymag, 50)
         self.assertEqual(cam.aspect_ratio, 1.3)
-        
+
         cam.xmag = 20
-        with self.assertRaises(collada.DaeMalformedError):
+        with self.assertRaises(DaeMalformedError):
             cam.save()
 
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/collada/tests/test_collada.py
+++ b/collada/tests/test_collada.py
@@ -1,12 +1,13 @@
-import unittest2
-import collada
-from lxml.etree import fromstring, tostring
-from StringIO import StringIO
-import numpy
 import os
+import numpy
 import dateutil.parser
+from lxml.etree import fromstring, tostring
 
-class TestCollada(unittest2.TestCase):
+import collada
+from collada.util import unittest, BytesIO
+
+
+class TestCollada(unittest.TestCase):
 
     def setUp(self):
         self.dummy = collada.Collada(validate_output=True)
@@ -15,13 +16,13 @@ class TestCollada(unittest2.TestCase):
     def test_collada_duck_tris(self):
         f = os.path.join(self.datadir, "duck_triangles.dae")
         mesh = collada.Collada(f, validate_output=True)
-        
+
         self.assertEqual(mesh.assetInfo.contributors[0].author, 'gcorson')
         self.assertEqual(mesh.assetInfo.contributors[0].authoring_tool, 'Maya 8.0 | ColladaMaya v3.02 | FCollada v3.2')
         self.assertEqual(mesh.assetInfo.contributors[0].source_data, 'file:///C:/vs2005/sample_data/Complete_Packages/SCEA_Private/Maya_MoonLander/Moonlander/untitled')
         self.assertEqual(len(mesh.assetInfo.contributors[0].copyright), 595)
         self.assertEqual(len(mesh.assetInfo.contributors[0].comments), 449)
-        
+
         self.assertEqual(mesh.assetInfo.unitmeter, 0.01)
         self.assertEqual(mesh.assetInfo.unitname, 'centimeter')
         self.assertEqual(mesh.assetInfo.upaxis, collada.asset.UP_AXIS.Y_UP)
@@ -31,7 +32,7 @@ class TestCollada(unittest2.TestCase):
         self.assertIsNone(mesh.assetInfo.keywords)
         self.assertEqual(mesh.assetInfo.created, dateutil.parser.parse('2006-08-23T22:29:59Z'))
         self.assertEqual(mesh.assetInfo.modified, dateutil.parser.parse('2007-02-21T22:52:44Z'))
-        
+
         self.assertEqual(mesh.scene.id, 'VisualSceneNode')
         self.assertIn('LOD3spShape-lib', mesh.geometries)
         self.assertIn('directionalLightShape1-lib', mesh.lights)
@@ -41,23 +42,23 @@ class TestCollada(unittest2.TestCase):
         self.assertIn('blinn3', mesh.materials)
         self.assertEqual(len(mesh.nodes), 0)
         self.assertIn('VisualSceneNode', mesh.scenes)
-        
+
         self.assertIsNotNone(str(list(mesh.scene.objects('geometry'))))
         self.assertIsNotNone(str(list(mesh.scene.objects('light'))))
         self.assertIsNotNone(str(list(mesh.scene.objects('camera'))))
-        
-        s = StringIO()
+
+        s = BytesIO()
         mesh.write(s)
         out = s.getvalue()
-        t = StringIO(out)
+        t = BytesIO(out)
         mesh = collada.Collada(t, validate_output=True)
-                
+
         self.assertEqual(mesh.assetInfo.contributors[0].author, 'gcorson')
         self.assertEqual(mesh.assetInfo.contributors[0].authoring_tool, 'Maya 8.0 | ColladaMaya v3.02 | FCollada v3.2')
         self.assertEqual(mesh.assetInfo.contributors[0].source_data, 'file:///C:/vs2005/sample_data/Complete_Packages/SCEA_Private/Maya_MoonLander/Moonlander/untitled')
         self.assertEqual(len(mesh.assetInfo.contributors[0].copyright), 595)
         self.assertEqual(len(mesh.assetInfo.contributors[0].comments), 449)
-        
+
         self.assertEqual(mesh.assetInfo.unitmeter, 0.01)
         self.assertEqual(mesh.assetInfo.unitname, 'centimeter')
         self.assertEqual(mesh.assetInfo.upaxis, collada.asset.UP_AXIS.Y_UP)
@@ -67,7 +68,7 @@ class TestCollada(unittest2.TestCase):
         self.assertIsNone(mesh.assetInfo.keywords)
         self.assertEqual(mesh.assetInfo.created, dateutil.parser.parse('2006-08-23T22:29:59Z'))
         self.assertEqual(mesh.assetInfo.modified, dateutil.parser.parse('2007-02-21T22:52:44Z'))
-        
+
         self.assertEqual(mesh.scene.id, 'VisualSceneNode')
         self.assertIn('LOD3spShape-lib', mesh.geometries)
         self.assertIn('directionalLightShape1-lib', mesh.lights)
@@ -77,11 +78,11 @@ class TestCollada(unittest2.TestCase):
         self.assertIn('blinn3', mesh.materials)
         self.assertEqual(len(mesh.nodes), 0)
         self.assertIn('VisualSceneNode', mesh.scenes)
-        
+
         self.assertIsNotNone(str(list(mesh.scene.objects('geometry'))))
         self.assertIsNotNone(str(list(mesh.scene.objects('light'))))
         self.assertIsNotNone(str(list(mesh.scene.objects('camera'))))
-                
+
     def test_collada_duck_poly(self):
         f = os.path.join(self.datadir, "duck_polylist.dae")
         mesh = collada.Collada(f, validate_output=True)
@@ -94,13 +95,13 @@ class TestCollada(unittest2.TestCase):
         self.assertIn('blinn3', mesh.materials)
         self.assertEqual(len(mesh.nodes), 0)
         self.assertIn('VisualSceneNode', mesh.scenes)
-        
-        s = StringIO()
+
+        s = BytesIO()
         mesh.write(s)
         out = s.getvalue()
-        t = StringIO(out)
+        t = BytesIO(out)
         mesh = collada.Collada(t, validate_output=True)
-        
+
         self.assertEqual(mesh.scene.id, 'VisualSceneNode')
         self.assertIn('LOD3spShape-lib', mesh.geometries)
         self.assertIn('directionalLightShape1-lib', mesh.lights)
@@ -110,7 +111,7 @@ class TestCollada(unittest2.TestCase):
         self.assertIn('blinn3', mesh.materials)
         self.assertEqual(len(mesh.nodes), 0)
         self.assertIn('VisualSceneNode', mesh.scenes)
-        
+
     def test_collada_duck_zip(self):
         f = os.path.join(self.datadir, "duck.zip")
         mesh = collada.Collada(f, validate_output=True)
@@ -124,7 +125,7 @@ class TestCollada(unittest2.TestCase):
         self.assertEqual(len(mesh.nodes), 0)
         self.assertIn('VisualSceneNode', mesh.scenes)
 
-    def test_collada_saving(self):       
+    def test_collada_saving(self):
         mesh = collada.Collada(validate_output=True)
 
         self.assertEqual(len(mesh.geometries), 0)
@@ -142,7 +143,7 @@ class TestCollada(unittest2.TestCase):
         floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1,0.2,0.3]), ('X', 'Y', 'Z'))
         geometry1 = collada.geometry.Geometry(mesh, "geometry1", "mygeometry1", {"myfloatsource":floatsource})
         mesh.geometries.append(geometry1)
-        
+
         linefloats = [1,1,-1, 1,-1,-1, -1,-0.9999998,-1, -0.9999997,1,-1, 1,0.9999995,1, 0.9999994,-1.000001,1]
         linefloatsrc = collada.source.FloatSource("mylinevertsource", numpy.array(linefloats), ('X', 'Y', 'Z'))
         geometry2 = collada.geometry.Geometry(mesh, "geometry2", "mygeometry2", [linefloatsrc])
@@ -152,39 +153,39 @@ class TestCollada(unittest2.TestCase):
         lineset1 = geometry2.createLineSet(indices, input_list, "mymaterial2")
         geometry2.primitives.append(lineset1)
         mesh.geometries.append(geometry2)
-        
+
         ambientlight = collada.light.AmbientLight("myambientlight", (1,1,1))
         pointlight = collada.light.PointLight("mypointlight", (1,1,1))
         mesh.lights.append(ambientlight)
         mesh.lights.append(pointlight)
-        
+
         camera1 = collada.camera.PerspectiveCamera("mycam1", 45.0, 0.01, 1000.0)
         camera2 = collada.camera.PerspectiveCamera("mycam2", 45.0, 0.01, 1000.0)
         mesh.cameras.append(camera1)
         mesh.cameras.append(camera2)
-        
+
         cimage1 = collada.material.CImage("mycimage1", "./whatever.tga", mesh)
         cimage2 = collada.material.CImage("mycimage2", "./whatever.tga", mesh)
         mesh.images.append(cimage1)
         mesh.images.append(cimage2)
-        
+
         effect1 = collada.material.Effect("myeffect1", [], "phong")
         effect2 = collada.material.Effect("myeffect2", [], "phong")
         mesh.effects.append(effect1)
         mesh.effects.append(effect2)
-        
+
         mat1 = collada.material.Material("mymaterial1", "mymat1", effect1)
         mat2 = collada.material.Material("mymaterial2", "mymat2", effect2)
         mesh.materials.append(mat1)
         mesh.materials.append(mat2)
-        
+
         rotate = collada.scene.RotateTransform(0.1, 0.2, 0.3, 90)
         scale = collada.scene.ScaleTransform(0.1, 0.2, 0.3)
         mynode1 = collada.scene.Node('mynode1', children=[], transforms=[rotate, scale])
         mynode2 = collada.scene.Node('mynode2', children=[], transforms=[])
         mesh.nodes.append(mynode1)
         mesh.nodes.append(mynode2)
-        
+
         geomnode = collada.scene.GeometryNode(geometry2)
         mynode3 = collada.scene.Node('mynode3', children=[geomnode], transforms=[])
         mynode4 = collada.scene.Node('mynode4', children=[], transforms=[])
@@ -192,14 +193,14 @@ class TestCollada(unittest2.TestCase):
         scene2 = collada.scene.Scene('myscene2', [mynode4])
         mesh.scenes.append(scene1)
         mesh.scenes.append(scene2)
-        
+
         mesh.scene = scene1
-        
-        out = StringIO()
+
+        out = BytesIO()
         mesh.write(out)
-        
-        toload = StringIO(out.getvalue())
-        
+
+        toload = BytesIO(out.getvalue())
+
         loaded_mesh = collada.Collada(toload, validate_output=True)
         self.assertEqual(len(loaded_mesh.geometries), 2)
         self.assertEqual(len(loaded_mesh.controllers), 0)
@@ -211,7 +212,7 @@ class TestCollada(unittest2.TestCase):
         self.assertEqual(len(loaded_mesh.nodes), 2)
         self.assertEqual(len(loaded_mesh.scenes), 2)
         self.assertEqual(loaded_mesh.scene.id, scene1.id)
-        
+
         self.assertIn('geometry1', loaded_mesh.geometries)
         self.assertIn('geometry2', loaded_mesh.geometries)
         self.assertIn('mypointlight', loaded_mesh.lights)
@@ -228,49 +229,49 @@ class TestCollada(unittest2.TestCase):
         self.assertIn('mynode2', loaded_mesh.nodes)
         self.assertIn('myscene1', loaded_mesh.scenes)
         self.assertIn('myscene2', loaded_mesh.scenes)
-        
+
         linefloatsrc2 = collada.source.FloatSource("mylinevertsource2", numpy.array(linefloats), ('X', 'Y', 'Z'))
         geometry3 = collada.geometry.Geometry(mesh, "geometry3", "mygeometry3", [linefloatsrc2])
         loaded_mesh.geometries.pop(0)
         loaded_mesh.geometries.append(geometry3)
-        
+
         dirlight = collada.light.DirectionalLight("mydirlight", (1,1,1))
         loaded_mesh.lights.pop(0)
         loaded_mesh.lights.append(dirlight)
-        
+
         camera3 = collada.camera.PerspectiveCamera("mycam3", 45.0, 0.01, 1000.0)
         loaded_mesh.cameras.pop(0)
         loaded_mesh.cameras.append(camera3)
-        
+
         cimage3 = collada.material.CImage("mycimage3", "./whatever.tga", loaded_mesh)
         loaded_mesh.images.pop(0)
         loaded_mesh.images.append(cimage3)
-        
+
         effect3 = collada.material.Effect("myeffect3", [], "phong")
         loaded_mesh.effects.pop(0)
         loaded_mesh.effects.append(effect3)
-        
+
         mat3 = collada.material.Material("mymaterial3", "mymat3", effect3)
         loaded_mesh.materials.pop(0)
         loaded_mesh.materials.append(mat3)
-        
+
         mynode5 = collada.scene.Node('mynode5', children=[], transforms=[])
         loaded_mesh.nodes.pop(0)
         loaded_mesh.nodes.append(mynode5)
-        
+
         mynode6 = collada.scene.Node('mynode6', children=[], transforms=[])
         scene3 = collada.scene.Scene('myscene3', [mynode6])
         loaded_mesh.scenes.pop(0)
         loaded_mesh.scenes.append(scene3)
-        
+
         loaded_mesh.scene = scene3
-        
+
         loaded_mesh.save()
-        
+
         strdata = tostring(loaded_mesh.xmlnode)
-        indata = StringIO(strdata)
+        indata = BytesIO(strdata)
         loaded_mesh2 = collada.Collada(indata, validate_output=True)
-        
+
         self.assertEqual(loaded_mesh2.scene.id, scene3.id)
         self.assertIn('geometry3', loaded_mesh2.geometries)
         self.assertIn('geometry2', loaded_mesh2.geometries)
@@ -288,7 +289,7 @@ class TestCollada(unittest2.TestCase):
         self.assertIn('mynode2', loaded_mesh2.nodes)
         self.assertIn('myscene3', loaded_mesh2.scenes)
         self.assertIn('myscene2', loaded_mesh2.scenes)
-        
+
     def test_collada_attribute_replace(self):
         mesh = collada.Collada(validate_output=True)
         self.assertIsInstance(mesh.geometries, collada.util.IndexedList)
@@ -301,7 +302,7 @@ class TestCollada(unittest2.TestCase):
         self.assertIsInstance(mesh.materials, collada.util.IndexedList)
         self.assertIsInstance(mesh.nodes, collada.util.IndexedList)
         self.assertIsInstance(mesh.scenes, collada.util.IndexedList)
-        
+
         mesh.geometries = []
         mesh.controllers = []
         mesh.animations = []
@@ -312,7 +313,7 @@ class TestCollada(unittest2.TestCase):
         mesh.materials = []
         mesh.nodes = []
         mesh.scenes = []
-        
+
         self.assertIsInstance(mesh.geometries, collada.util.IndexedList)
         self.assertIsInstance(mesh.controllers, collada.util.IndexedList)
         self.assertIsInstance(mesh.animations, collada.util.IndexedList)
@@ -325,4 +326,4 @@ class TestCollada(unittest2.TestCase):
         self.assertIsInstance(mesh.scenes, collada.util.IndexedList)
 
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/collada/tests/test_geometry.py
+++ b/collada/tests/test_geometry.py
@@ -1,13 +1,15 @@
-import unittest2
-import collada
-from lxml.etree import fromstring, tostring
 import numpy
+from lxml.etree import fromstring, tostring
 
-class TestGeometry(unittest2.TestCase):
+import collada
+from collada.util import unittest
+
+
+class TestGeometry(unittest.TestCase):
 
     def setUp(self):
         self.dummy = collada.Collada(validate_output=True)
-        
+
     def test_empty_geometry_saving(self):
         floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1,0.2,0.3]), ('X', 'Y', 'Z'))
         geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mygeometry", {"myfloatsource":floatsource})
@@ -16,7 +18,7 @@ class TestGeometry(unittest2.TestCase):
         self.assertEqual(len(geometry.primitives), 0)
         self.assertDictEqual(geometry.sourceById, {"myfloatsource":floatsource})
         self.assertIsNotNone(str(geometry))
-        
+
         geometry.id = "geometry1"
         geometry.name = "yourgeometry"
         othersource1 = collada.source.FloatSource("yourfloatsource", numpy.array([0.4,0.5,0.6]), ('X', 'Y', 'Z'))
@@ -25,7 +27,7 @@ class TestGeometry(unittest2.TestCase):
         geometry.sourceById[othersource2.id] = othersource2
         del geometry.sourceById[floatsource.id]
         geometry.save()
-        
+
         loaded_geometry = collada.geometry.Geometry.load(collada, {}, fromstring(tostring(geometry.xmlnode)))
         self.assertEqual(loaded_geometry.id, "geometry1")
         self.assertEqual(loaded_geometry.name, "yourgeometry")
@@ -33,7 +35,7 @@ class TestGeometry(unittest2.TestCase):
         self.assertIn(othersource1.id, loaded_geometry.sourceById)
         self.assertIn(othersource2.id, loaded_geometry.sourceById)
         self.assertNotIn(floatsource.id, loaded_geometry.sourceById)
-        
+
     def test_geometry_lineset_adding(self):
         linefloats = [1,1,-1, 1,-1,-1, -1,-0.9999998,-1, -0.9999997,1,-1, 1,0.9999995,1, 0.9999994,-1.000001,1]
         linefloatsrc = collada.source.FloatSource("mylinevertsource", numpy.array(linefloats), ('X', 'Y', 'Z'))
@@ -49,20 +51,20 @@ class TestGeometry(unittest2.TestCase):
         self.assertIsNotNone(str(lineset1))
         self.assertIsNotNone(str(input_list))
         geometry.save()
-        
+
         loaded_geometry = collada.geometry.Geometry.load(self.dummy, {}, fromstring(tostring(geometry.xmlnode)))
         self.assertEqual(len(loaded_geometry.primitives), 2)
 
         loaded_geometry.primitives.pop(0)
         lineset3 = loaded_geometry.createLineSet(indices, input_list, "mymaterial")
-        
+
         loaded_lineset = collada.lineset.LineSet.load(self.dummy, geometry.sourceById, fromstring(tostring(lineset3.xmlnode)))
         self.assertEqual(len(loaded_lineset), 5)
-        
+
         loaded_geometry.primitives.append(lineset3)
         loaded_geometry.save()
         loaded_geometry2 = collada.geometry.Geometry.load(self.dummy, {}, fromstring(tostring(loaded_geometry.xmlnode)))
-        
+
         self.assertEqual(len(loaded_geometry2.primitives), 2)
         self.assertEqual(loaded_geometry2.primitives[0].material, lineset2.material)
         self.assertEqual(loaded_geometry2.primitives[1].material, lineset3.material)
@@ -75,13 +77,13 @@ class TestGeometry(unittest2.TestCase):
         normal_src = collada.source.FloatSource("cubenormals-array", numpy.array(normal_floats), ('X', 'Y', 'Z'))
         self.assertEqual(len(vert_src), 8)
         self.assertEqual(len(normal_src), 24)
-        
+
         geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mycube", [vert_src, normal_src], [])
-        
+
         input_list = collada.source.InputList()
         input_list.addInput(0, 'VERTEX', "#cubeverts-array")
         input_list.addInput(1, 'NORMAL', "#cubenormals-array")
-        
+
         indices = numpy.array([0,0,2,1,3,2,0,0,3,2,1,3,0,4,1,5,5,6,0,4,5,6,4,7,6,8,7,9,3,10,6,8,3,10,2,11,0,12,
                         4,13,6,14,0,12,6,14,2,15,3,16,7,17,5,18,3,16,5,18,1,19,5,20,7,21,6,22,5,20,6,22,4,23])
         triangleset = geometry.createTriangleSet(indices, input_list, "cubematerial")
@@ -102,43 +104,43 @@ class TestGeometry(unittest2.TestCase):
                          -1,0,0,-1,0,0,-1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1]
         vert_src = collada.source.FloatSource("cubeverts-array", numpy.array(vert_floats), ('X', 'Y', 'Z'))
         normal_src = collada.source.FloatSource("cubenormals-array", numpy.array(normal_floats), ('X', 'Y', 'Z'))
-        
+
         geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mycube", [vert_src, normal_src], [])
-        
+
         input_list = collada.source.InputList()
         input_list.addInput(0, 'VERTEX', "#cubeverts-array")
         input_list.addInput(1, 'NORMAL', "#cubenormals-array")
-        
+
         vcounts = numpy.array([4,4,4,4,4,4])
         indices = numpy.array([0,0,2,1,3,2,1,3,0,4,1,5,5,6,4,7,6,8,7,9,3,10,2,11,0,12,4,13,6,14,2,
                                15,3,16,7,17,5,18,1,19,5,20,7,21,6,22,4,23])
         polylist = geometry.createPolylist(indices, vcounts, input_list, "cubematerial")
         self.assertIsNotNone(str(polylist))
-        
+
         loaded_polylist = collada.polylist.Polylist.load(self.dummy, geometry.sourceById, fromstring(tostring(polylist.xmlnode)))
         self.assertEqual(len(loaded_polylist), 6)
-        
+
         geometry.primitives.append(polylist)
         geometry.save()
 
         loaded_geometry = collada.geometry.Geometry.load(self.dummy, {}, fromstring(tostring(geometry.xmlnode)))
-        
+
         self.assertEqual(len(loaded_geometry.primitives), 1)
         self.assertEqual(len(loaded_geometry.primitives[0]), 6)
-        
+
     def test_geometry_polygons_adding(self):
         vert_floats = [-50,50,50,50,50,50,-50,-50,50,50,-50,50,-50,50,-50,50,50,-50,-50,-50,-50,50,-50,-50]
         normal_floats = [0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,
                          -1,0,0,-1,0,0,-1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1]
         vert_src = collada.source.FloatSource("cubeverts-array", numpy.array(vert_floats), ('X', 'Y', 'Z'))
         normal_src = collada.source.FloatSource("cubenormals-array", numpy.array(normal_floats), ('X', 'Y', 'Z'))
-        
+
         geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mycube", [vert_src, normal_src], [])
-        
+
         input_list = collada.source.InputList()
         input_list.addInput(0, 'VERTEX', "#cubeverts-array")
         input_list.addInput(1, 'NORMAL', "#cubenormals-array")
-        
+
         indices = []
         indices.append(numpy.array([0,0,2,1,3,2,1,3], dtype=numpy.int32))
         indices.append(numpy.array([0,4,1,5,5,6,4,7], dtype=numpy.int32))
@@ -149,17 +151,17 @@ class TestGeometry(unittest2.TestCase):
 
         polygons = geometry.createPolygons(indices, input_list, "cubematerial")
         self.assertIsNotNone(str(polygons))
-        
+
         loaded_polygons = collada.polygons.Polygons.load(self.dummy, geometry.sourceById, fromstring(tostring(polygons.xmlnode)))
         self.assertEqual(len(loaded_polygons), 6)
-        
+
         geometry.primitives.append(polygons)
         geometry.save()
 
         loaded_geometry = collada.geometry.Geometry.load(self.dummy, {}, fromstring(tostring(geometry.xmlnode)))
-        
+
         self.assertEqual(len(loaded_geometry.primitives), 1)
         self.assertEqual(len(loaded_geometry.primitives[0]), 6)
 
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/collada/tests/test_light.py
+++ b/collada/tests/test_light.py
@@ -1,8 +1,10 @@
-import unittest2
-import collada
 from lxml.etree import fromstring, tostring
 
-class TestLight(unittest2.TestCase):
+import collada
+from collada.util import unittest
+
+
+class TestLight(unittest.TestCase):
 
     def setUp(self):
         self.dummy = collada.Collada(validate_output=True)
@@ -20,7 +22,7 @@ class TestLight(unittest2.TestCase):
         self.assertTrue(isinstance(loaded_dirlight, collada.light.DirectionalLight))
         self.assertTupleEqual(loaded_dirlight.color, (0.1, 0.2, 0.3))
         self.assertEqual(loaded_dirlight.id, "yourdirlight")
-        
+
     def test_ambient_light_saving(self):
         ambientlight = collada.light.AmbientLight("myambientlight", (1,1,1))
         self.assertEqual(ambientlight.id, "myambientlight")
@@ -33,7 +35,7 @@ class TestLight(unittest2.TestCase):
         self.assertTrue(isinstance(loaded_ambientlight, collada.light.AmbientLight))
         self.assertTupleEqual(ambientlight.color, (0.1, 0.2, 0.3))
         self.assertEqual(ambientlight.id, "yourambientlight")
-        
+
     def test_point_light_saving(self):
         pointlight = collada.light.PointLight("mypointlight", (1,1,1))
         self.assertEqual(pointlight.id, "mypointlight")
@@ -58,12 +60,12 @@ class TestLight(unittest2.TestCase):
         self.assertEqual(loaded_pointlight.quad_att, 0.9)
         self.assertEqual(loaded_pointlight.zfar, None)
         self.assertEqual(loaded_pointlight.id, "yourpointlight")
-        
+
         loaded_pointlight.zfar = 0.2
         loaded_pointlight.save()
         loaded_pointlight = collada.light.Light.load(self.dummy, {}, fromstring(tostring(loaded_pointlight.xmlnode)))
         self.assertEqual(loaded_pointlight.zfar, 0.2)
-        
+
     def test_spot_light_saving(self):
         spotlight = collada.light.SpotLight("myspotlight", (1,1,1))
         self.assertEqual(spotlight.id, "myspotlight")
@@ -90,14 +92,14 @@ class TestLight(unittest2.TestCase):
         self.assertEqual(loaded_spotlight.falloff_ang, None)
         self.assertEqual(loaded_spotlight.falloff_exp, None)
         self.assertEqual(loaded_spotlight.id, "yourspotlight")
-        
+
         loaded_spotlight.falloff_ang = 180
         loaded_spotlight.falloff_exp = 2
         loaded_spotlight.save()
         loaded_spotlight = collada.light.Light.load(self.dummy, {}, fromstring(tostring(loaded_spotlight.xmlnode)))
         self.assertEqual(loaded_spotlight.falloff_ang, 180)
         self.assertEqual(loaded_spotlight.falloff_exp, 2)
-        
+
 
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/collada/tests/test_material.py
+++ b/collada/tests/test_material.py
@@ -1,14 +1,17 @@
-import unittest2
-import collada
-from lxml.etree import fromstring, tostring
 import os
 import sys
+from lxml.etree import fromstring, tostring
 
-class TestMaterial(unittest2.TestCase):
+import collada
+from collada.util import unittest
+
+
+class TestMaterial(unittest.TestCase):
 
     def setUp(self):
-        self.dummy = collada.Collada(aux_file_loader = self.image_dummy_loader, validate_output=True)
-        
+        self.dummy = collada.Collada(aux_file_loader = self.image_dummy_loader,
+                validate_output=True)
+
         self.dummy_cimage = collada.material.CImage("yourcimage", "./whatever.tga", self.dummy)
         self.cimage = collada.material.CImage("mycimage", "./whatever.tga", self.dummy)
         self.dummy.images.append(self.dummy_cimage)
@@ -27,7 +30,7 @@ class TestMaterial(unittest2.TestCase):
                        reflectivity = 0.8,
                        transparent = (0.2, 0.4, 0.6, 1.0),
                        transparency = 0.9)
-        
+
         self.assertEqual(effect.id, "myeffect")
         self.assertEqual(effect.shininess, 0.4)
         self.assertEqual(effect.reflectivity, 0.8)
@@ -40,7 +43,7 @@ class TestMaterial(unittest2.TestCase):
         self.assertTupleEqual(effect.transparent, (0.2, 0.4, 0.6, 1.0))
         self.assertEqual(effect.double_sided, False)
         self.assertIsNotNone(str(effect))
-        
+
         effect.id = "youreffect"
         effect.shininess = 7.0
         effect.reflectivity = 2.0
@@ -53,10 +56,10 @@ class TestMaterial(unittest2.TestCase):
         effect.transparent = (1.2, 1.4, 1.6, 1.0)
         effect.double_sided = True
         effect.save()
-        
+
         loaded_effect = collada.material.Effect.load(self.dummy, {},
                                     fromstring(tostring(effect.xmlnode)))
-        
+
         self.assertEqual(loaded_effect.id, "youreffect")
         self.assertEqual(loaded_effect.shininess, 7.0)
         self.assertEqual(loaded_effect.reflectivity, 2.0)
@@ -68,11 +71,11 @@ class TestMaterial(unittest2.TestCase):
         self.assertTupleEqual(loaded_effect.reflective, (1.7, 1.6, 1.5, 0.3))
         self.assertTupleEqual(loaded_effect.transparent, (1.2, 1.4, 1.6, 1.0))
         self.assertEqual(loaded_effect.double_sided, True)
-        
+
     def image_dummy_loader(self, fname):
         return self.image_return
         pass
-    
+
     def test_cimage_saving(self):
         self.image_return = None
         cimage = collada.material.CImage("mycimage", "./whatever.tga", self.dummy)
@@ -89,15 +92,15 @@ class TestMaterial(unittest2.TestCase):
         self.assertEqual(loaded_cimage.uintarray, None)
         self.assertEqual(loaded_cimage.floatarray, None)
         self.assertIsNotNone(str(cimage))
-        
+
     def test_cimage_data_loading(self):
         data_dir = os.path.join(os.path.dirname(os.path.realpath( __file__ )), "data")
         texture_file_path = os.path.join(data_dir, "duckCM.tga")
         self.failUnless(os.path.isfile(texture_file_path), "Could not find data/duckCM.tga file for testing")
-        
+
         texdata = open(texture_file_path, 'rb').read()
         self.assertEqual(len(texdata), 786476)
-        
+
         self.image_return = texdata
         cimage = collada.material.CImage("mycimage", "./whatever.tga", self.dummy)
         image_data = cimage.data
@@ -105,10 +108,10 @@ class TestMaterial(unittest2.TestCase):
         pil_image = cimage.pilimage
         self.assertTupleEqual(pil_image.size, (512,512))
         self.assertEqual(pil_image.format, "TGA")
-        
+
         numpy_uints = cimage.uintarray
         self.assertTupleEqual(numpy_uints.shape, (512, 512, 3))
-        
+
         numpy_floats = cimage.floatarray
         self.assertTupleEqual(numpy_uints.shape, (512, 512, 3))
 
@@ -127,7 +130,7 @@ class TestMaterial(unittest2.TestCase):
         self.assertEqual(loaded_surface.id, "yoursurface")
         self.assertEqual(loaded_surface.image.id, "yourcimage")
         self.assertEqual(loaded_surface.format, "OtherFormat")
-        
+
     def test_sampler2d_saving(self):
         cimage = collada.material.CImage("mycimage", "./whatever.tga", self.dummy)
         surface = collada.material.Surface("mysurface", cimage)
@@ -140,21 +143,21 @@ class TestMaterial(unittest2.TestCase):
         self.assertEqual(sampler2d.minfilter, "LINEAR_MIPMAP_LINEAR")
         self.assertEqual(sampler2d.magfilter, "LINEAR")
         self.assertIsNotNone(str(sampler2d))
-        
+
         other_surface = collada.material.Surface("yoursurface", cimage)
         sampler2d.id = "yoursampler2d"
         sampler2d.minfilter = "QUADRATIC_MIPMAP_WHAT"
         sampler2d.magfilter = "QUADRATIC"
         sampler2d.surface = other_surface
         sampler2d.save()
-        
+
         loaded_sampler2d = collada.material.Sampler2D.load(self.dummy,
                                 {'yoursurface':other_surface}, fromstring(tostring(sampler2d.xmlnode)))
         self.assertEqual(loaded_sampler2d.id, "yoursampler2d")
         self.assertEqual(loaded_sampler2d.surface.id, "yoursurface")
         self.assertEqual(loaded_sampler2d.minfilter, "QUADRATIC_MIPMAP_WHAT")
         self.assertEqual(loaded_sampler2d.magfilter, "QUADRATIC")
-    
+
     def test_map_saving(self):
         cimage = collada.material.CImage("mycimage", "./whatever.tga", self.dummy)
         surface = collada.material.Surface("mysurface", cimage)
@@ -163,17 +166,17 @@ class TestMaterial(unittest2.TestCase):
         self.assertEqual(map.sampler.id, "mysampler2d")
         self.assertEqual(map.texcoord, "TEX0")
         self.assertIsNotNone(str(map))
-        
+
         other_sampler2d = collada.material.Sampler2D("yoursampler2d", surface)
         map.sampler = other_sampler2d
         map.texcoord = "TEX1"
         map.save()
-        
+
         loaded_map = collada.material.Map.load(self.dummy,
                             {'yoursampler2d': other_sampler2d}, fromstring(tostring(map.xmlnode)))
         self.assertEqual(map.sampler.id, "yoursampler2d")
         self.assertEqual(map.texcoord, "TEX1")
-        
+
     def test_effect_with_params(self):
         surface = collada.material.Surface("mysurface", self.cimage)
         sampler2d = collada.material.Sampler2D("mysampler2d", surface)
@@ -187,7 +190,7 @@ class TestMaterial(unittest2.TestCase):
                        reflectivity = 0.8,
                        transparent = (0.2, 0.4, 0.6, 1.0),
                        transparency = 0.9)
-        
+
         other_cimage = collada.material.CImage("yourcimage", "./whatever.tga", self.dummy)
         other_surface = collada.material.Surface("yoursurface", other_cimage)
         other_sampler2d = collada.material.Sampler2D("yoursampler2d", other_surface)
@@ -198,7 +201,7 @@ class TestMaterial(unittest2.TestCase):
         effect.diffuse = other_map
         effect.transparent = other_map
         effect.save()
-        
+
         self.dummy.images.append(self.dummy_cimage)
         loaded_effect = collada.material.Effect.load(self.dummy, {}, fromstring(tostring(effect.xmlnode)))
         self.assertEqual(type(loaded_effect.diffuse), collada.material.Map)
@@ -218,16 +221,17 @@ class TestMaterial(unittest2.TestCase):
         self.assertEqual(mat.name, "mymat")
         self.assertEqual(mat.effect, effect)
         self.assertIsNotNone(str(mat))
-        
+
         mat.id = "yourmaterial"
         mat.name = "yourmat"
         mat.effect = self.othereffect
         mat.save()
-        
+
         loaded_mat = collada.material.Material.load(self.dummy, {}, fromstring(tostring(mat.xmlnode)))
         self.assertEqual(loaded_mat.id, "yourmaterial")
         self.assertEqual(loaded_mat.name, "yourmat")
         self.assertEqual(loaded_mat.effect.id, self.othereffect.id)
 
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()
+

--- a/collada/tests/test_scene.py
+++ b/collada/tests/test_scene.py
@@ -1,19 +1,21 @@
-import unittest2
-import collada
 import numpy
 from lxml.etree import fromstring, tostring
 
-class TestScene(unittest2.TestCase):
+import collada
+from collada.util import unittest
+
+
+class TestScene(unittest.TestCase):
 
     def setUp(self):
         self.dummy = collada.Collada(validate_output=True)
-        
+
         self.yourcam = collada.camera.PerspectiveCamera("yourcam", 45.0, 0.01, 1000.0)
         self.dummy.cameras.append(self.yourcam)
-        
+
         self.yourdirlight = collada.light.DirectionalLight("yourdirlight", (1,1,1))
         self.dummy.lights.append(self.yourdirlight)
-        
+
         cimage = collada.material.CImage("mycimage", "./whatever.tga", self.dummy)
         surface = collada.material.Surface("mysurface", cimage)
         sampler2d = collada.material.Sampler2D("mysampler2d", surface)
@@ -29,7 +31,7 @@ class TestScene(unittest2.TestCase):
                        specular = (0.3, 0.2, 0.1))
         self.dummy.materials.append(self.effect)
         self.dummy.materials.append(self.effect2)
-        
+
         self.floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1,0.2,0.3]), ('X', 'Y', 'Z'))
         self.geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mygeometry", {"myfloatsource":self.floatsource})
         self.geometry2 = collada.geometry.Geometry(self.dummy, "geometry1", "yourgeometry", {"myfloatsource":self.floatsource})
@@ -44,13 +46,13 @@ class TestScene(unittest2.TestCase):
         self.assertEqual(len(bindtest), 1)
         self.assertEqual(bindtest[0].original, dirlight)
         self.assertIsNotNone(str(lightnode))
-        
+
         lightnode.light = self.yourdirlight
         lightnode.save()
-        
+
         loadedlightnode = collada.scene.LightNode.load(self.dummy, fromstring(tostring(lightnode.xmlnode)))
         self.assertEqual(loadedlightnode.light.id, 'yourdirlight')
-        
+
     def test_scene_camera_node_saving(self):
         cam = collada.camera.PerspectiveCamera("mycam", 45.0, 0.01, 1000.0)
         camnode = collada.scene.CameraNode(cam)
@@ -59,10 +61,10 @@ class TestScene(unittest2.TestCase):
         self.assertEqual(len(bindtest), 1)
         self.assertEqual(bindtest[0].original, cam)
         self.assertIsNotNone(str(camnode))
-        
+
         camnode.camera = self.yourcam
         camnode.save()
-        
+
         loadedcamnode = collada.scene.CameraNode.load(self.dummy, fromstring(tostring(camnode.xmlnode)))
         self.assertEqual(loadedcamnode.camera.id, 'yourcam')
 
@@ -76,7 +78,7 @@ class TestScene(unittest2.TestCase):
         self.assertAlmostEqual(loaded_translate.x, 0.1)
         self.assertAlmostEqual(loaded_translate.y, 0.2)
         self.assertAlmostEqual(loaded_translate.z, 0.3)
-        
+
     def test_scene_rotate_node(self):
         rotate = collada.scene.RotateTransform(0.1, 0.2, 0.3, 90)
         self.assertAlmostEqual(rotate.x, 0.1)
@@ -89,7 +91,7 @@ class TestScene(unittest2.TestCase):
         self.assertAlmostEqual(loaded_rotate.y, 0.2)
         self.assertAlmostEqual(loaded_rotate.z, 0.3)
         self.assertAlmostEqual(loaded_rotate.angle, 90)
-        
+
     def test_scene_scale_node(self):
         scale = collada.scene.ScaleTransform(0.1, 0.2, 0.3)
         self.assertAlmostEqual(scale.x, 0.1)
@@ -100,14 +102,14 @@ class TestScene(unittest2.TestCase):
         self.assertAlmostEqual(loaded_scale.x, 0.1)
         self.assertAlmostEqual(loaded_scale.y, 0.2)
         self.assertAlmostEqual(loaded_scale.z, 0.3)
-        
+
     def test_scene_matrix_node(self):
         matrix = collada.scene.MatrixTransform(numpy.array([1.0,0,0,2, 0,1,0,3, 0,0,1,4, 0,0,0,1]))
         self.assertAlmostEqual(matrix.matrix[0][0], 1.0)
         self.assertIsNotNone(str(matrix))
         loaded_matrix = collada.scene.MatrixTransform.load(self.dummy, fromstring(tostring(matrix.xmlnode)))
         self.assertAlmostEqual(loaded_matrix.matrix[0][0], 1.0)
-        
+
     def test_scene_lookat_node(self):
         eye = numpy.array([2.0,0,3])
         interest = numpy.array([0.0,0,0])
@@ -121,7 +123,7 @@ class TestScene(unittest2.TestCase):
         self.assertListEqual(list(loaded_lookat.eye), list(eye))
         self.assertListEqual(list(loaded_lookat.interest), list(interest))
         self.assertListEqual(list(loaded_lookat.upvector), list(upvector))
-        
+
     def test_scene_node_combos(self):
         emptynode = collada.scene.Node('myemptynode')
         self.assertEqual(len(emptynode.children), 0)
@@ -130,7 +132,7 @@ class TestScene(unittest2.TestCase):
         loadedempty = collada.scene.Node.load(self.dummy, fromstring(tostring(emptynode.xmlnode)), {})
         self.assertEqual(len(loadedempty.children), 0)
         self.assertEqual(len(loadedempty.transforms), 0)
-        
+
         justchildren = collada.scene.Node('myjustchildrennode', children=[emptynode])
         self.assertEqual(len(justchildren.children), 1)
         self.assertEqual(len(justchildren.transforms), 0)
@@ -138,7 +140,7 @@ class TestScene(unittest2.TestCase):
         loadedjustchildren = collada.scene.Node.load(self.dummy, fromstring(tostring(justchildren.xmlnode)), {})
         self.assertEqual(len(loadedjustchildren.children), 1)
         self.assertEqual(len(loadedjustchildren.transforms), 0)
-        
+
         scale = collada.scene.ScaleTransform(0.1, 0.2, 0.3)
         justtransform = collada.scene.Node('myjusttransformnode', transforms=[scale])
         self.assertEqual(len(justtransform.children), 0)
@@ -147,7 +149,7 @@ class TestScene(unittest2.TestCase):
         loadedjusttransform = collada.scene.Node.load(self.dummy, fromstring(tostring(justtransform.xmlnode)), {})
         self.assertEqual(len(loadedjusttransform.children), 0)
         self.assertEqual(len(loadedjusttransform.transforms), 1)
-        
+
         both = collada.scene.Node('mybothnode', children=[justchildren, justtransform], transforms=[scale])
         self.assertEqual(len(both.children), 2)
         self.assertEqual(len(both.transforms), 1)
@@ -157,7 +159,7 @@ class TestScene(unittest2.TestCase):
         loadedboth = collada.scene.Node.load(self.dummy, fromstring(tostring(both.xmlnode)), {})
         self.assertEqual(len(both.children), 2)
         self.assertEqual(len(both.transforms), 1)
-        
+
     def test_scene_node_saving(self):
         myemptynode = collada.scene.Node('myemptynode')
         rotate = collada.scene.RotateTransform(0.1, 0.2, 0.3, 90)
@@ -167,7 +169,7 @@ class TestScene(unittest2.TestCase):
         self.assertEqual(mynode.children[0], myemptynode)
         self.assertEqual(mynode.transforms[0], rotate)
         self.assertEqual(mynode.transforms[1], scale)
-        
+
         translate = collada.scene.TranslateTransform(0.1, 0.2, 0.3)
         mynode.transforms.append(translate)
         mynode.transforms.pop(0)
@@ -190,7 +192,7 @@ class TestScene(unittest2.TestCase):
         binding2 = ("TEX1", "TEXCOORD", "1")
         binding3 = ("TEX2", "TEXCOORD", "2")
         matnode = collada.scene.MaterialNode("mygeommatref", self.effect, [binding1, binding2])
-        
+
         self.assertEqual(matnode.target, self.effect)
         self.assertEqual(matnode.symbol, "mygeommatref")
         self.assertListEqual(matnode.inputs, [binding1, binding2])
@@ -199,23 +201,23 @@ class TestScene(unittest2.TestCase):
         self.assertEqual(matnode.target, self.effect)
         self.assertEqual(matnode.symbol, "mygeommatref")
         self.assertListEqual(matnode.inputs, [binding1, binding2])
-        
+
         matnode.symbol = 'yourgeommatref'
         matnode.target = self.effect2
         matnode.inputs.append(binding3)
         matnode.inputs.pop(0)
         matnode.save()
-        
+
         loaded_matnode = collada.scene.MaterialNode.load(self.dummy, fromstring(tostring(matnode.xmlnode)))
         self.assertEqual(loaded_matnode.target.id, self.effect2.id)
         self.assertEqual(loaded_matnode.symbol, "yourgeommatref")
         self.assertListEqual(loaded_matnode.inputs, [binding2, binding3])
-        
+
     def test_scene_geometry_node(self):
         binding = ("TEX0", "TEXCOORD", "0")
         matnode = collada.scene.MaterialNode("mygeommatref", self.effect, [binding])
         geomnode = collada.scene.GeometryNode(self.geometry, [matnode])
-        
+
         bindtest = list(geomnode.objects('geometry'))
         self.assertEqual(len(bindtest), 1)
         self.assertEqual(bindtest[0].original, self.geometry)
@@ -228,20 +230,20 @@ class TestScene(unittest2.TestCase):
         self.assertEqual(bindtest[0].original, self.geometry)
         self.assertEqual(geomnode.geometry, self.geometry)
         self.assertListEqual(geomnode.materials, [matnode])
-        
+
         matnode2 = collada.scene.MaterialNode("yourgeommatref", self.effect, [binding])
         geomnode.materials.append(matnode2)
         geomnode.materials.pop(0)
         geomnode.geometry = self.geometry2
         geomnode.save()
-        
+
         loaded_geomnode = collada.scene.loadNode(self.dummy, fromstring(tostring(geomnode.xmlnode)), {})
         self.assertEqual(loaded_geomnode.geometry.id, self.geometry2.id)
         self.assertEqual(len(loaded_geomnode.materials), 1)
         self.assertEqual(loaded_geomnode.materials[0].target, matnode2.target)
         self.assertEqual(loaded_geomnode.materials[0].symbol, "yourgeommatref")
         self.assertListEqual(loaded_geomnode.materials[0].inputs, [binding])
-    
+
     def test_scene_node_with_instances(self):
         binding = ("TEX0", "TEXCOORD", "0")
         matnode = collada.scene.MaterialNode("mygeommatref", self.effect, [binding])
@@ -254,7 +256,7 @@ class TestScene(unittest2.TestCase):
         mynode = collada.scene.Node('mynode',
                                     children=[myemptynode, geomnode, camnode, lightnode],
                                     transforms=[rotate, scale])
-        
+
         self.assertEqual(len(mynode.children), 4)
         self.assertEqual(mynode.children[0], myemptynode)
         self.assertEqual(mynode.children[1], geomnode)
@@ -262,11 +264,11 @@ class TestScene(unittest2.TestCase):
         self.assertEqual(mynode.children[3], lightnode)
         self.assertEqual(mynode.transforms[0], rotate)
         self.assertEqual(mynode.transforms[1], scale)
-        
+
         mynode.id = 'yournode'
         mynode.children.pop(0)
         mynode.save()
-        
+
         yournode = collada.scene.Node.load(self.dummy, fromstring(tostring(mynode.xmlnode)), {})
         self.assertEqual(yournode.id, 'yournode')
         self.assertEqual(len(yournode.children), 3)
@@ -276,7 +278,7 @@ class TestScene(unittest2.TestCase):
         self.assertEqual(yournode.children[2].light.id, self.yourdirlight.id)
         self.assertTrue(type(yournode.transforms[0]) is collada.scene.RotateTransform)
         self.assertTrue(type(yournode.transforms[1]) is collada.scene.ScaleTransform)
-        
+
     def test_scene_with_nodes(self):
         rotate = collada.scene.RotateTransform(0.1, 0.2, 0.3, 90)
         scale = collada.scene.ScaleTransform(0.1, 0.2, 0.3)
@@ -284,26 +286,26 @@ class TestScene(unittest2.TestCase):
         yournode = collada.scene.Node('yournode', children=[], transforms=[])
         othernode = collada.scene.Node('othernode', children=[], transforms=[])
         scene = collada.scene.Scene('myscene', [mynode, yournode, othernode])
-        
+
         self.assertEqual(scene.id, 'myscene')
         self.assertEqual(len(scene.nodes), 3)
         self.assertEqual(scene.nodes[0], mynode)
         self.assertEqual(scene.nodes[1], yournode)
         self.assertEqual(scene.nodes[2], othernode)
-        
+
         scene.id = 'yourscene'
         scene.nodes.pop(1)
         anothernode = collada.scene.Node('anothernode')
         scene.nodes.append(anothernode)
         scene.save()
-        
+
         loaded_scene = collada.scene.Scene.load(self.dummy, fromstring(tostring(scene.xmlnode)))
-        
+
         self.assertEqual(loaded_scene.id, 'yourscene')
         self.assertEqual(len(loaded_scene.nodes), 3)
         self.assertEqual(loaded_scene.nodes[0].id, 'mynode')
         self.assertEqual(loaded_scene.nodes[1].id, 'othernode')
         self.assertEqual(loaded_scene.nodes[2].id, 'anothernode')
-        
+
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/collada/tests/test_source.py
+++ b/collada/tests/test_source.py
@@ -1,13 +1,15 @@
-import unittest2
-import collada
-from lxml.etree import fromstring, tostring
 import numpy
+from lxml.etree import fromstring, tostring
 
-class TestSource(unittest2.TestCase):
+import collada
+from collada.util import unittest
+
+
+class TestSource(unittest.TestCase):
 
     def setUp(self):
         self.dummy = collada.Collada(validate_output=True)
-        
+
     def test_float_source_saving(self):
         floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1,0.2,0.3]), ('X', 'Y', 'X'))
         self.assertEqual(floatsource.id, "myfloatsource")
@@ -23,7 +25,7 @@ class TestSource(unittest2.TestCase):
         self.assertEqual(floatsource.id, "yourfloatsource")
         self.assertEqual(len(floatsource), 3)
         self.assertTupleEqual(floatsource.components, ('S', 'T'))
-        
+
     def test_idref_source_saving(self):
         idrefsource = collada.source.IDRefSource("myidrefsource",
                                 numpy.array(['Ref1', 'Ref2'], dtype=numpy.string_),
@@ -41,7 +43,7 @@ class TestSource(unittest2.TestCase):
         self.assertEqual(loaded_idrefsource.id, "youridrefsource")
         self.assertEqual(len(loaded_idrefsource), 3)
         self.assertTupleEqual(loaded_idrefsource.components, ('JOINT_TARGET', 'WHATEVER_TARGET'))
-        
+
     def test_name_source_saving(self):
         namesource = collada.source.NameSource("mynamesource",
                                 numpy.array(['Name1', 'Name2'], dtype=numpy.string_),
@@ -59,6 +61,6 @@ class TestSource(unittest2.TestCase):
         self.assertEqual(loaded_namesource.id, "yournamesource")
         self.assertEqual(len(loaded_namesource), 3)
         self.assertTupleEqual(loaded_namesource.components, ('WEIGHT', 'WHATEVER'))
-        
+
 if __name__ == '__main__':
-    unittest2.main()
+    unittest.main()

--- a/collada/util.py
+++ b/collada/util.py
@@ -14,13 +14,30 @@
 
 import numpy
 import math
+import sys
 
-from collada import DaeMalformedError, tag, E
+if sys.version_info[0] > 2:
+    import unittest
+    from io import StringIO, BytesIO
+    bytes = bytes
+    basestring = (str,bytes)
+    xrange = range
+else:
+    import unittest2 as unittest
+    from StringIO import StringIO
+    BytesIO = StringIO
+    def bytes(s, encoding='utf-8'):
+        return s
+    basestring = basestring
+    xrange = xrange
+
+from collada.common import DaeMalformedError, E, tag
+
 
 def falmostEqual(a, b, rtol=1.0000000000000001e-05, atol=1e-08):
     """Checks if the given floats are almost equal. Uses the algorithm
     from numpy.allclose.
-    
+
     :param float a:
       First float to compare
     :param float b:
@@ -29,21 +46,21 @@ def falmostEqual(a, b, rtol=1.0000000000000001e-05, atol=1e-08):
       The relative tolerance parameter
     :param float atol:
       The absolute tolerance parameter
-      
+
     :rtype: bool
-      
+
     """
-    
+
     return math.fabs(a - b) <= (atol + rtol * math.fabs(b))
 
 def toUnitVec(vec):
     """Converts the given vector to a unit vector
-    
+
     :param numpy.array vec:
       The vector to transform to unit length
-      
+
     :rtype: numpy.array
-    
+
     """
     return vec / numpy.sqrt(numpy.vdot(vec, vec))
 
@@ -68,19 +85,19 @@ def checkSource( source, components, maxindex):
     #adapt to the failed output of others...
     if len(source.components) == len(components):
         source.components = components
-    
+
     if source.components != components:
         raise DaeMalformedError('Wrong format in source %s'%source.id)
     return source
 
 def normalize_v3(arr):
     """Normalize a numpy array of 3 component vectors with shape (N,3)
-    
+
     :param numpy.array arr:
       The numpy array to normalize
-    
+
     :rtype: numpy.array
-    
+
     """
     lens = numpy.sqrt( arr[:,0]**2 + arr[:,1]**2 + arr[:,2]**2 )
     lens[numpy.equal(lens, 0)] = 1
@@ -91,14 +108,14 @@ def normalize_v3(arr):
 
 def dot_v3(arr1, arr2):
     """Calculates the dot product for each vector in two arrays
-    
+
     :param numpy.array arr1:
       The first array, shape Nx3
     :param numpy.array arr2:
       The second array, shape Nx3
-    
+
     :rtype: numpy.array
-    
+
     """
     return arr1[:,0]*arr2[:,0] + arr1[:,1]*arr2[:,1] + arr2[:,2]*arr1[:,2]
 


### PR DESCRIPTION
Hi all,

the changes here are mostly py3k exception handling (backwards compatible), and some PEP code style for improved readability/productivity while working with pycollada. The motivation here is blender. Blender has had COLLADA importer written in Python before. Recent versions however replaced it with C++ (OpenCOLLADA) based importer, unfortunately that one isn't very stable and lacks features, and it's difficult to develop upon (OpenCOLLADA being one of the reasons). After discussion with jesterking (current COLLADA importer developer) we reached a conclusion that it's better to have a pythonic one, so that more people can contribute to it. Blender's scripting environment runs on Python 3.2.

Tests are passing on both Python 2.7 and 3.2, there is just one failing, perhaps you could help me with that one? I intent to actively work with you on pycollada to get it into good shape, supporting all the features.
