### PR TITLE
fix #29

### DIFF
--- a/collada/material.py
+++ b/collada/material.py
@@ -29,7 +29,7 @@ from collada.util import falmostEqual, StringIO
 from collada.xmlutil import etree as ElementTree
 
 try:
-    import Image as pil
+    from PIL import Image as pil
 except:
     pil = None
 
@@ -618,7 +618,7 @@ class Effect(DaeObject):
                 except DaeUnsupportedError as ex:
                     props[key] = None
                     collada.handleError(ex) # Give the chance to ignore error and load the rest
-                
+
                 if key == 'transparent' and key in props and props[key] is not None:
                     opaque_mode = pnode.get('opaque')
                     if opaque_mode is not None and opaque_mode == OPAQUE_MODE.RGB_ZERO:
@@ -873,4 +873,3 @@ class Material(DaeObject):
 
     def __repr__(self):
         return str(self)
-

--- a/collada/tests/test_material.py
+++ b/collada/tests/test_material.py
@@ -115,7 +115,7 @@ class TestMaterial(unittest.TestCase):
         self.assertEqual(len(image_data), 786476)
         
         try:
-            import Image as pil
+            from PIL import Image as pil
         except ImportError:
             pil = None
             


### PR DESCRIPTION
I confirmed that 

```
try:
    import Image
except ImportError:
    from PIL import Image
```

still conflict with pylab and possibly other packages using `from PIL import Image`

The reason might be that in PIL, when `import Image` fails, they will just do something like sys.exit() instead of throwing exceptions.

Now I simply changed it to `from PIL import Image` and I can use pylab in ipython with pycollada. 
