### PR TITLE
Fix FutureWarning from numpy

### DIFF
--- a/collada/scene.py
+++ b/collada/scene.py
@@ -368,7 +368,7 @@ class Node(SceneNode):
         :rtype: generator that yields the type specified
 
         """
-        if matrix != None: M = numpy.dot( matrix, self.matrix )
+        if not matrix is None: M = numpy.dot( matrix, self.matrix )
         else: M = self.matrix
         for node in self.children:
             for obj in node.objects(tipo, M):


### PR DESCRIPTION
Fix the following warning from numpy 1.9.0:
"FutureWarning: comparison to `None` will result in an elementwise object comparison in the future."
