### PR TITLE
Fix Python 3 image loading

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,4 +10,5 @@ Authors (Ordered by date of first contribution)
 * Ole Laursen
 * Andrey Nechypurenko (andreynech AT gmail.com)
 * Guohui Xiao (xiao AT kr.tuwien.ac.at)
+* Hannes Gräuler (graeuler AT geoplex.de)
 

--- a/collada/material.py
+++ b/collada/material.py
@@ -25,7 +25,7 @@ import numpy
 from collada.common import DaeObject, E, tag
 from collada.common import DaeIncompleteError, DaeBrokenRefError, \
         DaeMalformedError, DaeUnsupportedError
-from collada.util import falmostEqual, StringIO
+from collada.util import falmostEqual, BytesIO
 from collada.xmlutil import etree as ElementTree
 
 try:
@@ -98,7 +98,7 @@ class CImage(DaeObject):
                 self._pilimage = 'failed'
                 return None
             try:
-                self._pilimage = pil.open( StringIO(data) )
+                self._pilimage = pil.open( BytesIO(data) )
                 self._pilimage.load()
             except IOError as ex:
                 self._pilimage = 'failed'


### PR DESCRIPTION
This fixes ``pilimage`` property on Python 3:

    Traceback (most recent call last):
    (..)
      File "/usr/lib/python3.5/site-packages/collada/material.py", line 101, in getImage
        self._pilimage = pil.open( StringIO(data) )
    TypeError: initial_value must be str or None, not bytes
