### PR TITLE
Unfix python-dateutil; it supports 2.7 now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,12 @@ install_requires = []
 try: import numpy
 except ImportError: install_requires.append('numpy')
 
-if sys.version_info[0] > 2:
-    install_requires.append('python-dateutil>=2.0')
-else:
+install_requires.append('python-dateutil>=2.2')
+
+if sys.version_info[0] < 3:
     import unittest
     if not hasattr(unittest.TestCase, "assertIsNone"):
         install_requires.append('unittest2')
-    install_requires.append('python-dateutil==1.5')
 
 setup(
     name = "pycollada",


### PR DESCRIPTION
The dependency version of `python-dateutil` was fixed to 1.5 in [this commit](https://github.com/pycollada/pycollada/commit/a8ee9294079070df9d511a7e85be8e6ce2b4dea4), six years ago.

At the time, the latest version of `python-dateutil` was Python 3.0-only, but more recent versions of the library support both Pythons (cf. https://github.com/dateutil/dateutil/releases).