### PR TITLE
Update python-dateutil in collada15spec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,12 @@ install_requires = []
 try: import numpy
 except ImportError: install_requires.append('numpy')
 
-if sys.version_info[0] > 2:
-    install_requires.append('python-dateutil>=2.0')
-else:
+install_requires.append('python-dateutil>=2.2')
+
+if sys.version_info[0] < 3:
     import unittest
     if not hasattr(unittest.TestCase, "assertIsNone"):
         install_requires.append('unittest2')
-    install_requires.append('python-dateutil==1.5')
 
 setup(
     name = "pycollada",

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,10 @@
 import sys
 from setuptools import find_packages, setup
 
-install_requires = []
+install_requires = ['python-dateutil>=2.2']
 
 try: import numpy
 except ImportError: install_requires.append('numpy')
-
-install_requires.append('python-dateutil>=2.2')
 
 if sys.version_info[0] < 3:
     import unittest


### PR DESCRIPTION
From pip 10 `install` or `upgrade` shows dependency warning, and sudo resets environment variable, making the warning unsuppressible.

(Actually I have told the detail and this is the relevant cherry-pick, so use this for fast solution.)