### PR TITLE
Fix ValueError in scene object matrix

### DIFF
--- a/collada/scene.py
+++ b/collada/scene.py
@@ -368,6 +368,8 @@ class Node(SceneNode):
         :rtype: generator that yields the type specified
 
         """
+        if isinstance(matrix, numpy.ndarray):
+            matrix = matrix.any()
         if not matrix is None: M = numpy.dot( matrix, self.matrix )
         else: M = self.matrix
         for node in self.children:


### PR DESCRIPTION
Version: 0.4-3 (debian linux)

Collada file which produces the traceback:
[Rib Test.zip](https://github.com/pycollada/pycollada/files/3076075/Rib.Test.zip)

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/share/freecad/Mod/Arch/importDAE.py", line 98, in insert
    read(filename)
  File "/usr/share/freecad/Mod/Arch/importDAE.py", line 122, in read
    if list(node.objects("geometry")):
  File "/usr/lib/python2.7/dist-packages/collada/scene.py", line 377, in objects
    for obj in node.objects(tipo, M):
  File "/usr/lib/python2.7/dist-packages/collada/scene.py", line 374, in objects
    if matrix != None: M = numpy.dot( matrix, self.matrix )
<type 'exceptions.ValueError'>: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```