### PR TITLE
fix package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
     url = "http://pycollada.readthedocs.org/",
     test_suite = "collada.tests",
     packages = find_packages(),
-    package_data={'pycollada': ['resources/*.xml']}
+    package_data={'collada': ['resources/*.xml']}
 )


### PR DESCRIPTION
Thanks for releasing! I noticed [some CI failures](https://circleci.com/gh/mikedh/trimesh/1215?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) related to the schema:
```
FileNotFoundError: [Errno 2] No such file or directory: '/home/mikedh/conda/lib/python3.7/site-packages/collada/resources/schema-1.4.1.xml'
```

I believe this is because `setup.py` references `pycollada`, but the actual package name is `collada`. I verified this PR fixes the issue on my machines. 