### PR TITLE
removed redundancy in unit normals and reformatted

### DIFF
--- a/docs/creating.rst
+++ b/docs/creating.rst
@@ -25,10 +25,7 @@ create a triangle set later::
     >>> import numpy
     >>> vert_floats = [-50,50,50,50,50,50,-50,-50,50,50,
     ...     -50,50,-50,50,-50,50,50,-50,-50,-50,-50,50,-50,-50]
-    >>> normal_floats = [0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,
-    ...     0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,
-    ...     -1,0,0,-1,0,0,-1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,-1,
-    ...     0,0,-1,0,0,-1,0,0,-1]
+    >>> normal_floats = [0,0,1, 0,1,0, 0,-1,0, -1,0,0, 1,0,0, 0,0,-1]
     >>> vert_src = source.FloatSource("cubeverts-array", numpy.array(vert_floats), ('X', 'Y', 'Z'))
     >>> normal_src = source.FloatSource("cubenormals-array", numpy.array(normal_floats), ('X', 'Y', 'Z'))
 
@@ -50,10 +47,10 @@ and source with identifier `cubenormals-array` as the normal source. The offsets
 indicate that the vertex data is the first offset in the index array and the normal
 data is the second offset in the index array. Let's now create the index array::
     
-    >>> indices = numpy.array([0,0,2,1,3,2,0,0,3,2,1,3,0,4,1,5,5,6,0,
-    ...     4,5,6,4,7,6,8,7,9,3,10,6,8,3,10,2,11,0,12,
-    ...     4,13,6,14,0,12,6,14,2,15,3,16,7,17,5,18,3,
-    ...     16,5,18,1,19,5,20,7,21,6,22,5,20,6,22,4,23])
+    >>> indices = numpy.array([0,0,2,0,3,0, 0,0,3,0,1,0, 0,1,1,1,5,1,
+    ...                        0,1,5,1,4,1, 6,2,7,2,3,2, 6,2,3,2,2,2,
+    ...                        0,3,4,3,6,3, 0,3,6,3,2,3, 3,4,7,4,5,4,
+    ...                        3,4,5,4,1,4, 5,5,7,5,6,5, 5,5,6,5,4,5])
 
 Now that we have an index array, an input list, and a material, we can create a
 triangle set and add it to the geometry's list of primitives. We then add it to


### PR DESCRIPTION
I removed a redundancy in the unit normal's in "normal_floats" where the same unit normal's were repeated. Because they are accessed with indices only a single copy of each unit normal vector is required.  I also added spaces in "normal_floats" to help the artist see the vectors within it (this could also be done to vert_floats if you think is helpful).
I then updated "indices" references to the new unit normal's indices and reformatted "indices" so that the triangles are grouped. This also makes it clear that the unit normals index follows each vertex index.