### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/daeview/renderer/GLSLRenderer.py
+++ b/examples/daeview/renderer/GLSLRenderer.py
@@ -207,7 +207,7 @@ class GLSLRenderer:
                                               ('v3f/static', vertices),
                                               ('n3f/static', normals))
 
-                        # Append the batch with supplimentary
+                        # Append the batch with supplementary
                         # information to the batch list
                         self.batch_list.append(
                             (batch, shader_prog, tex_id, diff_color, 

--- a/examples/daeview/renderer/shader.py
+++ b/examples/daeview/renderer/shader.py
@@ -15,7 +15,7 @@ def _as_bytes(s):
 
 class Shader:
 	# vert, frag and geom take arrays of source strings
-	# the arrays will be concattenated into one string by OpenGL
+	# the arrays will be concatenated into one string by OpenGL
 	def __init__(self, vert = [], frag = [], geom = []):
 		# create the program handle
 		self.handle = glCreateProgram()
@@ -132,7 +132,7 @@ class Shader:
 	# works with matrices stored as lists,
 	# as well as euclid matrices
 	def uniform_matrixf(self, name, mat):
-		# obtian the uniform location
+		# obtain the uniform location
 		loc = glGetUniformLocation(self.Handle, name)
 		# uplaod the 4x4 floating point matrix
 		glUniformMatrix4fv(loc, 1, False, (c_float * 16)(*mat))


### PR DESCRIPTION
There are small typos in:
- examples/daeview/renderer/GLSLRenderer.py
- examples/daeview/renderer/shader.py

Fixes:
- Should read `supplementary` rather than `supplimentary`.
- Should read `obtain` rather than `obtian`.
- Should read `concatenated` rather than `concattenated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md