### PR TITLE
Make numpy an explicit install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 import sys
 from setuptools import find_packages, setup
 
-install_requires = ['python-dateutil>=2.2']
-
-try: import numpy
-except ImportError: install_requires.append('numpy')
+install_requires = ['python-dateutil>=2.2', 'numpy']
 
 if sys.version_info[0] < 3:
     import unittest


### PR DESCRIPTION
On a project I am working on, we are using `pip-compile` to generate the `requirements.txt` for an application. 

Currently `pycollada` gets pulled in as a project dependency through `urdfpy`. Unfortunately, we are seeing an inconsistent list of dependencies get generated depending on the system where the `pip-compile` command is run. 

This appears to be due to the conditional logic in `setup.py` which only declares `numpy` as an install dependency of `pycollada` if it's not already installed on the system in question.

Shouldn't `numpy` always be part of the `install_requires` list (i.e., vs. having it be an implicit requirement if it already installed)?

This would generate consistent dependencies for the library.