### PR TITLE
Support multiple namespace

### DIFF
--- a/collada/__init__.py
+++ b/collada/__init__.py
@@ -215,15 +215,11 @@ class Collada(object):
         # if we can't get the current namespace
         # the tagger from above will use a hardcoded default
         try:
-            # get the root node, same for both etree and lxml
+            # get the root node (whose tag is assumed to be COLLADA),
+            # and extract ns from its tag
             xml_root = self.xmlnode.getroot()
-            if hasattr(xml_root, 'nsmap'):
-                # lxml has an nsmap
-                # use the first value in the namespace map
-                namespace = next(iter(xml_root.nsmap.values()))
-            elif hasattr(xml_root, 'tag'):
-                # for xml.etree we need to extract ns from root tag
-                namespace = xml_root.tag.split('}')[0].lstrip('{')
+            namespace = xml_root.tag.split('}')[0].lstrip('{')
+
             # create a tagging function using the extracted namespace
             self.tag = tagger(namespace)
         except BaseException:

--- a/collada/tests/data/empty_triangles_with_multiple_ns.dae
+++ b/collada/tests/data/empty_triangles_with_multiple_ns.dae
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <library_geometries>
+    <geometry id="geom0">
+      <mesh>
+        <source id="geom0-vtx">
+          <float_array id="geom0-vtx-array" count="0"></float_array>
+          <technique_common>
+            <accessor source="#geom0-vtx-array" count="0" stride="0">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="geom0-mesh-vertices">
+          <input semantic="POSITION" source="#geom0-vtx"/>
+        </vertices>
+        	<triangles count="0" material="geom0-material">
+		  <input semantic="VERTEX" source="#geom0-mesh-vertices" offset="0" />
+	      <input semantic="TEXCOORD" source="#geom0-vtx" offset="1" set="0" />
+          <input semantic="NORMAL" source="#geom0-vtx" offset="2" />
+          <p>                           </p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="scene" name="scene">
+      <node>
+        <instance_geometry url="#geom0" />
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#scene"/>
+  </scene>
+</COLLADA>

--- a/collada/tests/test_collada.py
+++ b/collada/tests/test_collada.py
@@ -350,6 +350,12 @@ class TestCollada(unittest.TestCase):
         triangles = mesh.geometries[0].primitives[0]
         self.assertEqual(0, len(triangles))
 
+    def test_collada_empty_triangles_with_multiple_ns(self):
+        f = os.path.join(self.datadir, "empty_triangles_with_multiple_ns.dae")
+        mesh = collada.Collada(f, validate_output=True)
+        triangles = mesh.geometries[0].primitives[0]
+        self.assertEqual(0, len(triangles))
+
     def test_namespace(self):
         """
         Test loading a file with a different namespace.


### PR DESCRIPTION
Support multiple namespace in `.dae` file.

# Background
Hi, all. I have `example.dae` file whose collada element is as follows:

```collada
<?xml version="1.0" encoding="utf-8"?>
<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <asset>
    <contributor>
      <author>Blender User</author>
      <authoring_tool>Blender 2.90.0 commit date:2020-08-31, commit time:11:26, hash:0330d1af29c0</authoring_tool>
    </contributor>
...
  <library_visual_scenes>
    <visual_scene id="Scene" name="Scene">
    ...
    </visual_scene>
  </library_visual_scenes>
  <scene>
    <instance_visual_scene url="#Scene"/>
  </scene>
</COLLADA>

```
Please note that this file has two name spaces, and this is not invalid since collada file is a kind of XML file and follows both COLLADA Schema and XML Schema.
However, when this collada file is parsed with PyCollada, `scene` attribute is `None`, and that causes an error in some software.
```python
inport collada
with open('example.dae') as f:
    c = collada.Collada(f)
assert c.scene is not None # raise AssertionError
```

# Cause of the empty `scene` attribute
PyCollada get collada namespace in these lines.
https://github.com/pycollada/pycollada/blob/master/collada/__init__.py#L222-L223
These lines select the first namespace as collada namespace, but that is not always correct.
The bug above was caused by the bug in which the XML Schema URI was used as collada schema.

# What this PR do?
In this PR, select URIs which include "COLLADA", sort them in descending order, and use the first URI as collada schema.
If there are multiple URIs including "COLLADA", the last one in alphabetical order is used.
This process is intended to select latest collada xsd as collada schema, since the file is assumed to support the latest collada version (I don't know whether multiple collada URI could be appear in one `.dae` file, but it might be possible).
For example, if one file has collada 1.4 schema and collada 1.5 schema, schema of collada 1.5 will be selected.
```
Collada 1.4: https://www.collada.org/2005/11/COLLADASchema/
Collada 1.5: https://www.collada.org/2008/03/COLLADASchema/ # This URI will be used as collada schema
```

Thank you