### PR TITLE
Flake8 to pass on collada

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,8 +50,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy python-dateutil
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        # use setup.py to install the library 
+        pip install -e .
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,24 +13,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
-  formatting:
-    name: Check Formatting
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-    - name: Install Formatting
-      run: |
-        pip install autopep8 flake8
-    - name: Check Formatting
-      run: |
-        flake8 collada
-        autopep8 --recursive --aggressive --diff --exit-code collada/
-
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -53,9 +35,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82,W605 --show-source --statistics
+        flake8 collada --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 collada --count --exit-zero --max-complexity=10 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,8 +13,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
 
+  formatting:
+    name: Check Formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install Formatting
+      run: |
+        pip install autopep8 flake8
+    - name: Check Formatting
+      run: |
+        flake8 collada
+        autopep8 --recursive --aggressive --diff --exit-code collada/
+
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -49,7 +49,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip pytest
         # use setup.py to install the library 
         pip install -e .
     - name: Test with pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,10 +34,11 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
+        # stop the build if the library itthere are Python syntax errors or undefined names
         flake8 collada --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 collada --count --exit-zero --max-complexity=10 --statistics
+        # exit-zero treats all errors as warnings
+        # extend-select will add rules in addition to defaults
+        flake8 . --extend-select=E9,F63,F7,F82,W605 --count --exit-zero --max-complexity=10 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,8 +34,10 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        # stop the build if the library itthere are Python syntax errors or undefined names
-        flake8 collada --show-source --statistics
+        # stop the build if the library fails any
+        # default flake8 rule or the extended list here
+        flake8 collada --extend-select=E9,F63,F7,F82,W605 --show-source --statistics
+        # generate a report for the whole package
         # exit-zero treats all errors as warnings
         # extend-select will add rules in addition to defaults
         flake8 . --extend-select=E9,F63,F7,F82,W605 --count --exit-zero --max-complexity=10 --statistics

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,13 +13,34 @@ on:
   workflow_dispatch:
 
 jobs:
+  formatting:
+    name: Check Formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install Formatting
+      run: |
+        pip install autopep8 flake8 flake8-no-implicit-concat
+    - name: Check Formatting
+      run: |
+        # stop the build if the library fails any of the
+        # default flake8 rule or the extended list here
+        flake8 collada --extend-select=E9,F63,F7,F82,W605 --show-source --statistics
+        # generate a report for the whole package
+        # exit-zero treats all errors as warnings
+        # extend-select will add rules in addition to defaults
+        flake8 . --extend-select=E9,F63,F7,F82,W605 --count --exit-zero --max-complexity=10 --statistics
   build:
     runs-on: ubuntu-latest
+    needs: formatting
     strategy:
       fail-fast: false
       matrix:
         python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -29,18 +50,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
         python -m pip install numpy python-dateutil
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if the library fails any
-        # default flake8 rule or the extended list here
-        flake8 collada --extend-select=E9,F63,F7,F82,W605 --show-source --statistics
-        # generate a report for the whole package
-        # exit-zero treats all errors as warnings
-        # extend-select will add rules in addition to defaults
-        flake8 . --extend-select=E9,F63,F7,F82,W605 --count --exit-zero --max-complexity=10 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/collada/__init__.py
+++ b/collada/__init__.py
@@ -23,9 +23,7 @@ __version__ = "0.4.1"
 import os.path
 import posixpath
 import traceback
-import types
 import zipfile
-from datetime import datetime
 
 from collada import animation
 from collada import asset
@@ -36,9 +34,8 @@ from collada import light
 from collada import material
 from collada import scene
 from collada.common import E, tagger, tag
-from collada.common import DaeError, DaeObject, DaeIncompleteError, \
-    DaeBrokenRefError, DaeMalformedError, DaeUnsupportedError, \
-    DaeSaveValidationError
+from collada.common import DaeError, DaeIncompleteError, DaeBrokenRefError, \
+    DaeMalformedError, DaeSaveValidationError
 from collada.util import basestring, BytesIO
 from collada.util import IndexedList
 from collada.xmlutil import etree as ElementTree
@@ -46,33 +43,33 @@ from collada.xmlutil import writeXML
 
 try:
     from collada import schema
-except ImportError: # no lxml
+except ImportError:  # no lxml
     schema = None
 
 
 class Collada(object):
     """This is the main class used to create and load collada documents"""
 
-    geometries = property( lambda s: s._geometries, lambda s,v: s._setIndexedList('_geometries', v), doc="""
-    A list of :class:`collada.geometry.Geometry` objects. Can also be indexed by id""" )
-    controllers = property( lambda s: s._controllers, lambda s,v: s._setIndexedList('_controllers', v), doc="""
-    A list of :class:`collada.controller.Controller` objects. Can also be indexed by id""" )
-    animations = property( lambda s: s._animations, lambda s,v: s._setIndexedList('_animations', v), doc="""
-    A list of :class:`collada.animation.Animation` objects. Can also be indexed by id""" )
-    lights = property( lambda s: s._lights, lambda s,v: s._setIndexedList('_lights', v), doc="""
-    A list of :class:`collada.light.Light` objects. Can also be indexed by id""" )
-    cameras = property( lambda s: s._cameras, lambda s,v: s._setIndexedList('_cameras', v), doc="""
-    A list of :class:`collada.camera.Camera` objects. Can also be indexed by id""" )
-    images = property( lambda s: s._images, lambda s,v: s._setIndexedList('_images', v), doc="""
-    A list of :class:`collada.material.CImage` objects. Can also be indexed by id""" )
-    effects = property( lambda s: s._effects, lambda s,v: s._setIndexedList('_effects', v), doc="""
-    A list of :class:`collada.material.Effect` objects. Can also be indexed by id""" )
-    materials = property( lambda s: s._materials, lambda s,v: s._setIndexedList('_materials', v), doc="""
-    A list of :class:`collada.material.Effect` objects. Can also be indexed by id""" )
-    nodes = property( lambda s: s._nodes, lambda s,v: s._setIndexedList('_nodes', v), doc="""
-    A list of :class:`collada.scene.Node` objects. Can also be indexed by id""" )
-    scenes = property( lambda s: s._scenes, lambda s,v: s._setIndexedList('_scenes', v), doc="""
-    A list of :class:`collada.scene.Scene` objects. Can also be indexed by id""" )
+    geometries = property(lambda s: s._geometries, lambda s, v: s._setIndexedList('_geometries', v), doc="""
+    A list of :class:`collada.geometry.Geometry` objects. Can also be indexed by id""")
+    controllers = property(lambda s: s._controllers, lambda s, v: s._setIndexedList('_controllers', v), doc="""
+    A list of :class:`collada.controller.Controller` objects. Can also be indexed by id""")
+    animations = property(lambda s: s._animations, lambda s, v: s._setIndexedList('_animations', v), doc="""
+    A list of :class:`collada.animation.Animation` objects. Can also be indexed by id""")
+    lights = property(lambda s: s._lights, lambda s, v: s._setIndexedList('_lights', v), doc="""
+    A list of :class:`collada.light.Light` objects. Can also be indexed by id""")
+    cameras = property(lambda s: s._cameras, lambda s, v: s._setIndexedList('_cameras', v), doc="""
+    A list of :class:`collada.camera.Camera` objects. Can also be indexed by id""")
+    images = property(lambda s: s._images, lambda s, v: s._setIndexedList('_images', v), doc="""
+    A list of :class:`collada.material.CImage` objects. Can also be indexed by id""")
+    effects = property(lambda s: s._effects, lambda s, v: s._setIndexedList('_effects', v), doc="""
+    A list of :class:`collada.material.Effect` objects. Can also be indexed by id""")
+    materials = property(lambda s: s._materials, lambda s, v: s._setIndexedList('_materials', v), doc="""
+    A list of :class:`collada.material.Effect` objects. Can also be indexed by id""")
+    nodes = property(lambda s: s._nodes, lambda s, v: s._setIndexedList('_nodes', v), doc="""
+    A list of :class:`collada.scene.Node` objects. Can also be indexed by id""")
+    scenes = property(lambda s: s._scenes, lambda s, v: s._setIndexedList('_scenes', v), doc="""
+    A list of :class:`collada.scene.Scene` objects. Can also be indexed by id""")
 
     def __init__(self,
                  filename=None,
@@ -138,7 +135,7 @@ class Collada(object):
 
         self.maskedErrors = []
         if ignore is not None:
-            self.ignoreErrors( *ignore )
+            self.ignoreErrors(*ignore)
 
         if filename is None:
             self.filename = None
@@ -148,18 +145,18 @@ class Collada(object):
                 self.getFileData = self._wrappedFileLoader(aux_file_loader)
 
             self.xmlnode = ElementTree.ElementTree(
-                               E.COLLADA(
-                                   E.library_cameras(),
-                                   E.library_controllers(),
-                                   E.library_effects(),
-                                   E.library_geometries(),
-                                   E.library_images(),
-                                   E.library_lights(),
-                                   E.library_materials(),
-                                   E.library_nodes(),
-                                   E.library_visual_scenes(),
-                                   E.scene(),
-                               version='1.4.1'))
+                E.COLLADA(
+                    E.library_cameras(),
+                    E.library_controllers(),
+                    E.library_effects(),
+                    E.library_geometries(),
+                    E.library_images(),
+                    E.library_lights(),
+                    E.library_materials(),
+                    E.library_nodes(),
+                    E.library_visual_scenes(),
+                    E.scene(),
+                    version='1.4.1'))
             """ElementTree representation of the collada document"""
 
             self.assetInfo = asset.Asset()
@@ -172,13 +169,13 @@ class Collada(object):
             self.filename = filename
             self.getFileData = self._getFileFromDisk
         else:
-            strdata = filename.read() # assume it is a file like object
+            strdata = filename.read()  # assume it is a file like object
             self.filename = None
             self.getFileData = self._nullGetFile
 
         try:
             self.zfile = zipfile.ZipFile(BytesIO(strdata), 'r')
-        except:
+        except BaseException:
             self.zfile = None
 
         if self.zfile:
@@ -205,10 +202,10 @@ class Collada(object):
         if aux_file_loader is not None:
             self.getFileData = self._wrappedFileLoader(aux_file_loader)
 
-        etree_parser = ElementTree.XMLParser()
+        ElementTree.XMLParser()
         try:
             self.xmlnode = ElementTree.ElementTree(element=None,
-                    file=BytesIO(data))
+                                                   file=BytesIO(data))
         except ElementTree.ParseError as e:
             raise DaeMalformedError("XML Parsing Error: %s" % e)
 
@@ -259,29 +256,30 @@ class Collada(object):
         mask so all exceptions abort the load just call c.ignoreErrors(None).
 
         """
-        if args == [ None ]:
+        if args == [None]:
             self.maskedErrors = []
         else:
-            for e in args: self.maskedErrors.append(e)
+            for e in args:
+                self.maskedErrors.append(e)
 
     def _getFileFromZip(self, fname):
         """Return the binary data of an auxiliary file from a zip archive as a string."""
         if not self.zfile:
-            raise DaeBrokenRefError('Trying to load an auxiliary file %s but we are not reading from a zip'%fname)
+            raise DaeBrokenRefError('Trying to load an auxiliary file %s but we are not reading from a zip' % fname)
         basepath = posixpath.dirname(self.filename)
         aux_path = posixpath.normpath(posixpath.join(basepath, fname))
         if aux_path not in self.zfile.namelist():
             raise DaeBrokenRefError('Auxiliar file %s not found in archive' % fname)
-        return self.zfile.read( aux_path )
+        return self.zfile.read(aux_path)
 
     def _getFileFromDisk(self, fname):
         """Return the binary data of an auxiliary file from the local disk relative to the file path loaded."""
         if self.zfile:
-            raise DaeBrokenRefError('Trying to load an auxiliary file %s from disk but we are reading from a zip file'%fname)
+            raise DaeBrokenRefError('Trying to load an auxiliary file %s from disk but we are reading from a zip file' % fname)
         basepath = os.path.dirname(self.filename)
         aux_path = os.path.normpath(os.path.join(basepath, fname))
         if not os.path.exists(aux_path):
-            raise DaeBrokenRefError('Auxiliar file %s not found on disk'%fname)
+            raise DaeBrokenRefError('Auxiliar file %s not found on disk' % fname)
         fdata = open(aux_path, 'rb')
         return fdata.read()
 
@@ -476,10 +474,10 @@ class Collada(object):
         """Loads the default scene from <scene> tag in the root node."""
         node = self.xmlnode.find('%s/%s' % (self.tag('scene'), self.tag('instance_visual_scene')))
         try:
-            if node != None:
+            if node is not None:
                 sceneid = node.get('url')
                 if not sceneid.startswith('#'):
-                    raise DaeMalformedError('Malformed default scene reference to %s: '%sceneid)
+                    raise DaeMalformedError('Malformed default scene reference to %s: ' % sceneid)
                 self.scene = self.scenes.get(sceneid[1:])
                 if not self.scene:
                     raise DaeBrokenRefError('Default scene %s not found' % sceneid)
@@ -507,15 +505,15 @@ class Collada(object):
         library_loc = 0
         for i, node in enumerate(self.xmlnode.getroot()):
             if node.tag == self.tag('asset'):
-                library_loc = i+1
+                library_loc = i + 1
 
         for arr, name in libraries:
-            node = self.xmlnode.find( self.tag(name) )
+            node = self.xmlnode.find(self.tag(name))
             if node is None:
                 if len(arr) == 0:
                     continue
                 self.xmlnode.getroot().insert(library_loc, E(name))
-                node = self.xmlnode.find( self.tag(name) )
+                node = self.xmlnode.find(self.tag(name))
             elif node is not None and len(arr) == 0:
                 self.xmlnode.getroot().remove(node)
                 continue
@@ -539,8 +537,9 @@ class Collada(object):
 
         if self.validator is not None:
             if not self.validator.validate(self.xmlnode):
-                raise DaeSaveValidationError("Validation error when saving: " + 
-                        self.validator.COLLADA_SCHEMA_1_4_1_INSTANCE.error_log.last_error.message)
+                raise DaeSaveValidationError(
+                    "Validation error when saving: {}".format(
+                        self.validator.COLLADA_SCHEMA_1_4_1_INSTANCE.error_log.last_error.message))
 
     def write(self, fp):
         """Writes out the collada document to a file. Note that this also
@@ -561,4 +560,3 @@ class Collada(object):
 
     def __repr__(self):
         return str(self)
-

--- a/collada/__init__.py
+++ b/collada/__init__.py
@@ -202,7 +202,6 @@ class Collada(object):
         if aux_file_loader is not None:
             self.getFileData = self._wrappedFileLoader(aux_file_loader)
 
-        ElementTree.XMLParser()
         try:
             self.xmlnode = ElementTree.ElementTree(element=None,
                                                    file=BytesIO(data))

--- a/collada/__main__.py
+++ b/collada/__main__.py
@@ -10,11 +10,11 @@
 #                                                                  #
 ####################################################################
 
+from collada.util import unittest
 import os
 import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from collada.util import unittest
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().discover("tests")

--- a/collada/animation.py
+++ b/collada/animation.py
@@ -16,6 +16,7 @@ from collada import source
 from collada.common import DaeObject
 from collada.common import DaeError
 
+
 class Animation(DaeObject):
     """Class for holding animation data coming from <animation> tags."""
 
@@ -29,7 +30,7 @@ class Animation(DaeObject):
             self.xmlnode = None
 
     @staticmethod
-    def load( collada, localscope, node ):
+    def load(collada, localscope, node):
         id = node.get('id') or ''
         name = node.get('name') or ''
 
@@ -53,5 +54,8 @@ class Animation(DaeObject):
         anim = Animation(id, name, sourcebyid, children, node)
         return anim
 
-    def __str__(self): return '<Animation id=%s, children=%d>' % (self.id, len(self.children))
-    def __repr__(self): return str(self)
+    def __str__(self):
+        return '<Animation id=%s, children=%d>' % (self.id, len(self.children))
+
+    def __repr__(self):
+        return str(self)

--- a/collada/asset.py
+++ b/collada/asset.py
@@ -12,15 +12,11 @@
 
 """Contains COLLADA asset information."""
 
-import numpy
 import datetime
 import dateutil.parser
 
-from collada.common import DaeObject, E, tag
-from collada.common import DaeIncompleteError, DaeBrokenRefError, \
-        DaeMalformedError, DaeUnsupportedError
+from collada.common import DaeObject, E
 from collada.util import _correctValInNode
-from collada.xmlutil import etree as ElementTree
 
 
 class UP_AXIS:
@@ -31,6 +27,7 @@ class UP_AXIS:
     """Indicates Y direction is up"""
     Z_UP = 'Z_UP'
     """Indicates Z direction is up"""
+
 
 class Contributor(DaeObject):
     """Defines authoring information for asset management"""
@@ -81,16 +78,21 @@ class Contributor(DaeObject):
 
     @staticmethod
     def load(collada, localscope, node):
-        author = node.find(collada.tag('author') )
-        authoring_tool = node.find(collada.tag('authoring_tool') )
-        comments = node.find(collada.tag('comments') )
-        copyright = node.find(collada.tag('copyright') )
-        source_data = node.find(collada.tag('source_data') )
-        if author is not None: author = author.text
-        if authoring_tool is not None: authoring_tool = authoring_tool.text
-        if comments is not None: comments = comments.text
-        if copyright is not None: copyright = copyright.text
-        if source_data is not None: source_data = source_data.text
+        author = node.find(collada.tag('author'))
+        authoring_tool = node.find(collada.tag('authoring_tool'))
+        comments = node.find(collada.tag('comments'))
+        copyright = node.find(collada.tag('copyright'))
+        source_data = node.find(collada.tag('source_data'))
+        if author is not None:
+            author = author.text
+        if authoring_tool is not None:
+            authoring_tool = authoring_tool.text
+        if comments is not None:
+            comments = comments.text
+        if copyright is not None:
+            copyright = copyright.text
+        if source_data is not None:
+            source_data = source_data.text
         return Contributor(author=author, authoring_tool=authoring_tool,
                            comments=comments, copyright=copyright, source_data=source_data, xmlnode=node)
 
@@ -102,14 +104,18 @@ class Contributor(DaeObject):
         _correctValInNode(self.xmlnode, 'copyright', self.copyright)
         _correctValInNode(self.xmlnode, 'source_data', self.source_data)
 
-    def __str__(self): return '<Contributor author=%s>' % (str(self.author),)
-    def __repr__(self): return str(self)
+    def __str__(self):
+        return '<Contributor author=%s>' % (str(self.author),)
+
+    def __repr__(self):
+        return str(self)
+
 
 class Asset(DaeObject):
     """Defines asset-management information"""
 
     def __init__(self, created=None, modified=None, title=None, subject=None, revision=None,
-               keywords=None, unitname=None, unitmeter=None, upaxis=None, contributors=None, xmlnode=None):
+                 keywords=None, unitname=None, unitmeter=None, upaxis=None, contributors=None, xmlnode=None):
         """Create a new set of information about an asset
 
         :param datetime.datetime created:
@@ -200,59 +206,68 @@ class Asset(DaeObject):
 
     @staticmethod
     def load(collada, localscope, node):
-        contributornodes = node.findall(collada.tag('contributor') )
+        contributornodes = node.findall(collada.tag('contributor'))
         contributors = []
         for contributornode in contributornodes:
             contributors.append(Contributor.load(collada, localscope, contributornode))
 
-        created = node.find(collada.tag('created') )
+        created = node.find(collada.tag('created'))
         if created is not None:
-            try: created = dateutil.parser.parse(created.text)
-            except: created = None
+            try:
+                created = dateutil.parser.parse(created.text)
+            except BaseException:
+                created = None
 
-        keywords = node.find(collada.tag('keywords') )
-        if keywords is not None: keywords = keywords.text
+        keywords = node.find(collada.tag('keywords'))
+        if keywords is not None:
+            keywords = keywords.text
 
-        modified = node.find(collada.tag('modified') )
+        modified = node.find(collada.tag('modified'))
         if modified is not None:
-            try: modified = dateutil.parser.parse(modified.text)
-            except: modified = None
+            try:
+                modified = dateutil.parser.parse(modified.text)
+            except BaseException:
+                modified = None
 
-        revision = node.find(collada.tag('revision') )
-        if revision is not None: revision = revision.text
+        revision = node.find(collada.tag('revision'))
+        if revision is not None:
+            revision = revision.text
 
-        subject = node.find(collada.tag('subject') )
-        if subject is not None: subject = subject.text
+        subject = node.find(collada.tag('subject'))
+        if subject is not None:
+            subject = subject.text
 
-        title = node.find(collada.tag('title') )
-        if title is not None: title = title.text
+        title = node.find(collada.tag('title'))
+        if title is not None:
+            title = title.text
 
-        unitnode = node.find(collada.tag('unit') )
+        unitnode = node.find(collada.tag('unit'))
         if unitnode is not None:
             unitname = unitnode.get('name')
-            try: unitmeter = float(unitnode.get('meter'))
-            except:
+            try:
+                unitmeter = float(unitnode.get('meter'))
+            except BaseException:
                 unitname = None
                 unitmeter = None
         else:
             unitname = None
             unitmeter = None
 
-        upaxis = node.find(collada.tag('up_axis') )
+        upaxis = node.find(collada.tag('up_axis'))
         if upaxis is not None:
             upaxis = upaxis.text
-            if not(upaxis == UP_AXIS.X_UP or upaxis == UP_AXIS.Y_UP or \
+            if not (upaxis == UP_AXIS.X_UP or
+                    upaxis == UP_AXIS.Y_UP or
                     upaxis == UP_AXIS.Z_UP):
                 upaxis = None
 
         return Asset(created=created, modified=modified, title=title,
-                subject=subject, revision=revision, keywords=keywords,
-                unitname=unitname, unitmeter=unitmeter, upaxis=upaxis,
-                contributors=contributors, xmlnode=node)
+                     subject=subject, revision=revision, keywords=keywords,
+                     unitname=unitname, unitmeter=unitmeter, upaxis=upaxis,
+                     contributors=contributors, xmlnode=node)
 
     def __str__(self):
         return '<Asset title=%s>' % (str(self.title),)
 
     def __repr__(self):
         return str(self)
-

--- a/collada/camera.py
+++ b/collada/camera.py
@@ -24,7 +24,7 @@ class Camera(DaeObject):
 
     @staticmethod
     def load(collada, localscope, node):
-        tecnode = node.find('%s/%s' % (collada.tag('optics'),collada.tag('technique_common')))
+        tecnode = node.find('%s/%s' % (collada.tag('optics'), collada.tag('technique_common')))
         if tecnode is None or len(tecnode) == 0:
             raise DaeIncompleteError('Missing common technique in camera')
         camnode = tecnode[0]
@@ -40,7 +40,7 @@ class PerspectiveCamera(Camera):
     """Perspective camera as defined in COLLADA tag <perspective>."""
 
     def __init__(self, id, znear, zfar, xfov=None, yfov=None,
-            aspect_ratio=None, xmlnode = None):
+                 aspect_ratio=None, xmlnode=None):
         """Create a new perspective camera.
 
         Note: ``aspect_ratio = tan(0.5*xfov) / tan(0.5*yfov)``
@@ -86,7 +86,7 @@ class PerspectiveCamera(Camera):
 
         self._checkValidParams()
 
-        if xmlnode is not  None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the data."""
         else:
@@ -105,8 +105,7 @@ class PerspectiveCamera(Camera):
         self.xmlnode = E.camera(
             E.optics(
                 E.technique_common(perspective_node)
-            )
-        , id=self.id, name=self.id)
+            ), id=self.id, name=self.id)
 
     def _checkValidParams(self):
         if self.xfov is not None and self.yfov is None \
@@ -126,27 +125,26 @@ class PerspectiveCamera(Camera):
             pass
         else:
             raise DaeMalformedError("Received invalid combination of xfov (%s), yfov (%s), and aspect_ratio (%s)" %
-                    (str(self.xfov), str(self.yfov), str(self.aspect_ratio)))
+                                    (str(self.xfov), str(self.yfov), str(self.aspect_ratio)))
 
     def save(self):
         """Saves the perspective camera's properties back to xmlnode"""
         self._checkValidParams()
         self._recreateXmlNode()
 
-
     @staticmethod
     def load(collada, localscope, node):
-        persnode = node.find( '%s/%s/%s'%(collada.tag('optics'),collada.tag('technique_common'),
-            collada.tag('perspective') ))
+        persnode = node.find('%s/%s/%s' % (collada.tag('optics'), collada.tag('technique_common'),
+                                           collada.tag('perspective')))
 
         if persnode is None:
             raise DaeIncompleteError('Missing perspective for camera definition')
 
-        xfov = persnode.find( collada.tag('xfov') )
-        yfov = persnode.find( collada.tag('yfov') )
-        aspect_ratio = persnode.find( collada.tag('aspect_ratio') )
-        znearnode = persnode.find( collada.tag('znear') )
-        zfarnode = persnode.find( collada.tag('zfar') )
+        xfov = persnode.find(collada.tag('xfov'))
+        yfov = persnode.find(collada.tag('yfov'))
+        aspect_ratio = persnode.find(collada.tag('aspect_ratio'))
+        znearnode = persnode.find(collada.tag('znear'))
+        zfarnode = persnode.find(collada.tag('zfar'))
         id = node.get('id', '')
 
         try:
@@ -158,17 +156,17 @@ class PerspectiveCamera(Camera):
                 aspect_ratio = float(aspect_ratio.text)
             znear = float(znearnode.text)
             zfar = float(zfarnode.text)
-        except (TypeError, ValueError) as ex:
+        except (TypeError, ValueError):
             raise DaeMalformedError('Corrupted float values in camera definition')
 
-        #There are some exporters that incorrectly output all three of these.
+        # There are some exporters that incorrectly output all three of these.
         # Worse, they actually got the calculation of aspect_ratio wrong!
         # So instead of failing to load, let's just add one more hack because of terrible exporters
         if xfov is not None and yfov is not None and aspect_ratio is not None:
             aspect_ratio = None
 
         return PerspectiveCamera(id, znear, zfar, xfov=xfov, yfov=yfov,
-                aspect_ratio=aspect_ratio, xmlnode=node)
+                                 aspect_ratio=aspect_ratio, xmlnode=node)
 
     def bind(self, matrix):
         """Create a bound camera of itself based on a transform matrix.
@@ -181,13 +179,17 @@ class PerspectiveCamera(Camera):
         """
         return BoundPerspectiveCamera(self, matrix)
 
-    def __str__(self): return '<PerspectiveCamera id=%s>' % self.id
-    def __repr__(self): return str(self)
+    def __str__(self):
+        return '<PerspectiveCamera id=%s>' % self.id
+
+    def __repr__(self):
+        return str(self)
+
 
 class OrthographicCamera(Camera):
     """Orthographic camera as defined in COLLADA tag <orthographic>."""
 
-    def __init__(self, id, znear, zfar, xmag=None, ymag=None, aspect_ratio=None, xmlnode = None):
+    def __init__(self, id, znear, zfar, xmag=None, ymag=None, aspect_ratio=None, xmlnode=None):
         """Create a new orthographic camera.
 
         Note: ``aspect_ratio = xmag / ymag``
@@ -233,7 +235,7 @@ class OrthographicCamera(Camera):
 
         self._checkValidParams()
 
-        if xmlnode is not  None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the data."""
         else:
@@ -252,8 +254,7 @@ class OrthographicCamera(Camera):
         self.xmlnode = E.camera(
             E.optics(
                 E.technique_common(orthographic_node)
-            )
-        , id=self.id, name=self.id)
+            ), id=self.id, name=self.id)
 
     def _checkValidParams(self):
         if self.xmag is not None and self.ymag is None \
@@ -273,13 +274,12 @@ class OrthographicCamera(Camera):
             pass
         else:
             raise DaeMalformedError("Received invalid combination of xmag (%s), ymag (%s), and aspect_ratio (%s)" %
-                    (str(self.xmag), str(self.ymag), str(self.aspect_ratio)))
+                                    (str(self.xmag), str(self.ymag), str(self.aspect_ratio)))
 
     def save(self):
         """Saves the orthographic camera's properties back to xmlnode"""
         self._checkValidParams()
         self._recreateXmlNode()
-
 
     @staticmethod
     def load(collada, localscope, node):
@@ -288,13 +288,14 @@ class OrthographicCamera(Camera):
             collada.tag('technique_common'),
             collada.tag('orthographic')))
 
-        if orthonode is None: raise DaeIncompleteError('Missing orthographic for camera definition')
+        if orthonode is None:
+            raise DaeIncompleteError('Missing orthographic for camera definition')
 
-        xmag = orthonode.find( collada.tag('xmag') )
-        ymag = orthonode.find( collada.tag('ymag') )
-        aspect_ratio = orthonode.find( collada.tag('aspect_ratio') )
-        znearnode = orthonode.find( collada.tag('znear') )
-        zfarnode = orthonode.find( collada.tag('zfar') )
+        xmag = orthonode.find(collada.tag('xmag'))
+        ymag = orthonode.find(collada.tag('ymag'))
+        aspect_ratio = orthonode.find(collada.tag('aspect_ratio'))
+        znearnode = orthonode.find(collada.tag('znear'))
+        zfarnode = orthonode.find(collada.tag('zfar'))
         id = node.get('id', '')
 
         try:
@@ -306,17 +307,17 @@ class OrthographicCamera(Camera):
                 aspect_ratio = float(aspect_ratio.text)
             znear = float(znearnode.text)
             zfar = float(zfarnode.text)
-        except (TypeError, ValueError) as ex:
+        except (TypeError, ValueError):
             raise DaeMalformedError('Corrupted float values in camera definition')
 
-        #There are some exporters that incorrectly output all three of these.
+        # There are some exporters that incorrectly output all three of these.
         # Worse, they actually got the calculation of aspect_ratio wrong!
         # So instead of failing to load, let's just add one more hack because of terrible exporters
         if xmag is not None and ymag is not None and aspect_ratio is not None:
             aspect_ratio = None
 
         return OrthographicCamera(id, znear, zfar, xmag=xmag, ymag=ymag,
-                aspect_ratio=aspect_ratio, xmlnode=node)
+                                  aspect_ratio=aspect_ratio, xmlnode=node)
 
     def bind(self, matrix):
         """Create a bound camera of itself based on a transform matrix.
@@ -335,9 +336,10 @@ class OrthographicCamera(Camera):
     def __repr__(self):
         return str(self)
 
+
 class BoundCamera(object):
     """Base class for bound cameras"""
-    pass
+
 
 class BoundPerspectiveCamera(BoundCamera):
     """Perspective camera bound to a scene with a transform. This gets created when a
@@ -356,11 +358,11 @@ class BoundPerspectiveCamera(BoundCamera):
         """Distance to the far clipping plane"""
         self.matrix = matrix
         """The matrix bound to"""
-        self.position = matrix[:3,3]
+        self.position = matrix[:3, 3]
         """The position of the camera"""
-        self.direction = -matrix[:3,2]
+        self.direction = -matrix[:3, 2]
         """The direction the camera is facing"""
-        self.up = matrix[:3,1]
+        self.up = matrix[:3, 1]
         """The up vector of the camera"""
         self.original = cam
         """Original :class:`collada.camera.PerspectiveCamera` object this is bound to."""
@@ -370,6 +372,7 @@ class BoundPerspectiveCamera(BoundCamera):
 
     def __repr__(self):
         return str(self)
+
 
 class BoundOrthographicCamera(BoundCamera):
     """Orthographic camera bound to a scene with a transform. This gets created when a
@@ -388,11 +391,11 @@ class BoundOrthographicCamera(BoundCamera):
         """Distance to the far clipping plane"""
         self.matrix = matrix
         """The matrix bound to"""
-        self.position = matrix[:3,3]
+        self.position = matrix[:3, 3]
         """The position of the camera"""
-        self.direction = -matrix[:3,2]
+        self.direction = -matrix[:3, 2]
         """The direction the camera is facing"""
-        self.up = matrix[:3,1]
+        self.up = matrix[:3, 1]
         """The up vector of the camera"""
         self.original = cam
         """Original :class:`collada.camera.OrthographicCamera` object this is bound to."""
@@ -402,4 +405,3 @@ class BoundOrthographicCamera(BoundCamera):
 
     def __repr__(self):
         return str(self)
-

--- a/collada/common.py
+++ b/collada/common.py
@@ -23,7 +23,7 @@ def tagger(namespace=None):
     """
     A closure, or function that returns a function.
     Returned function tags using a specified namespace.
-    
+
     :param string namespace:
       The XML namespace to use to tag elements
 
@@ -33,6 +33,7 @@ def tagger(namespace=None):
     def tag(text):
         return str(etree.QName(namespace, text))
     return tag
+
 
 class DaeObject(object):
     """This class is the abstract interface to all collada objects.
@@ -71,10 +72,12 @@ class DaeObject(object):
     def save(self):
         """Put all the data to the internal xml node (xmlnode) so it can be serialized."""
 
+
 class DaeError(Exception):
     """General DAE exception."""
+
     def __init__(self, msg):
-        super(DaeError,self).__init__()
+        super(DaeError, self).__init__()
         self.msg = msg
 
     def __str__(self):
@@ -83,23 +86,22 @@ class DaeError(Exception):
     def __repr__(self):
         return type(self).__name__ + '("' + self.msg + '")'
 
+
 class DaeIncompleteError(DaeError):
     """Raised when needed data for an object isn't there."""
-    pass
+
 
 class DaeBrokenRefError(DaeError):
     """Raised when a referenced object is not found in the scope."""
-    pass
+
 
 class DaeMalformedError(DaeError):
     """Raised when data is found to be corrupted in some way."""
-    pass
+
 
 class DaeUnsupportedError(DaeError):
     """Raised when some unexpectedly unsupported feature is found."""
-    pass
+
 
 class DaeSaveValidationError(DaeError):
     """Raised when XML validation fails when saving."""
-    pass
-

--- a/collada/controller.py
+++ b/collada/controller.py
@@ -303,7 +303,6 @@ class BoundSkinPrimitive(object):
 
     def shapes(self):
         for shape in self.primitive.shapes():
-            shape.indices
             yield shape
 
 

--- a/collada/geometry.py
+++ b/collada/geometry.py
@@ -182,9 +182,7 @@ class Geometry(DaeObject):
             sourcebyid[ch.id] = ch
 
         verticesnode = meshnode.find(collada.tag('vertices'))
-        if verticesnode is None:
-            pass
-        else:
+        if verticesnode is not None:
             inputnodes = {}
             for inputnode in verticesnode.findall(collada.tag('input')):
                 semantic = inputnode.get('semantic')

--- a/collada/light.py
+++ b/collada/light.py
@@ -15,10 +15,9 @@
 import numpy
 
 from collada.common import DaeObject, E, tag
-from collada.common import DaeIncompleteError, DaeBrokenRefError, \
-        DaeMalformedError, DaeUnsupportedError
+from collada.common import DaeIncompleteError, DaeMalformedError, \
+    DaeUnsupportedError
 from collada.util import _correctValInNode
-from collada.xmlutil import etree as ElementTree
 
 
 class Light(DaeObject):
@@ -26,26 +25,26 @@ class Light(DaeObject):
 
     @staticmethod
     def load(collada, localscope, node):
-        tecnode = node.find( collada.tag('technique_common') )
+        tecnode = node.find(collada.tag('technique_common'))
         if tecnode is None or len(tecnode) == 0:
             raise DaeIncompleteError('Missing common technique in light')
         lightnode = tecnode[0]
         if lightnode.tag == collada.tag('directional'):
-            return DirectionalLight.load( collada, localscope, node )
+            return DirectionalLight.load(collada, localscope, node)
         elif lightnode.tag == collada.tag('point'):
-            return PointLight.load( collada, localscope, node )
+            return PointLight.load(collada, localscope, node)
         elif lightnode.tag == collada.tag('ambient'):
-            return AmbientLight.load( collada, localscope, node )
+            return AmbientLight.load(collada, localscope, node)
         elif lightnode.tag == collada.tag('spot'):
-            return SpotLight.load( collada, localscope, node )
+            return SpotLight.load(collada, localscope, node)
         else:
-            raise DaeUnsupportedError('Unrecognized light type: %s'%lightnode.tag)
+            raise DaeUnsupportedError('Unrecognized light type: %s' % lightnode.tag)
 
 
 class DirectionalLight(Light):
     """Directional light as defined in COLLADA tag <directional> tag."""
 
-    def __init__(self, id, color, xmlnode = None):
+    def __init__(self, id, color, xmlnode=None):
         """Create a new directional light.
 
         :param str id:
@@ -60,14 +59,14 @@ class DirectionalLight(Light):
         """
         self.id = id
         """The unique string identifier for the light"""
-        self.direction = numpy.array( [0, 0, -1], dtype=numpy.float32 )
-        #Not documenting this because it doesn't make sense to set the direction
+        self.direction = numpy.array([0, 0, -1], dtype=numpy.float32)
+        # Not documenting this because it doesn't make sense to set the direction
         # of an unbound light. The direction isn't set until binding in a scene.
         self.color = color
         """Either a tuple of size 3 containing the RGB color value
           of the light or a tuple of size 4 containing the RGBA
           color value of the light"""
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the light."""
         else:
@@ -76,29 +75,27 @@ class DirectionalLight(Light):
                     E.directional(
                         E.color(' '.join(map(str, self.color)))
                     )
-                )
-            , id=self.id, name=self.id)
+                ), id=self.id, name=self.id)
 
     def save(self):
         """Saves the light's properties back to :attr:`xmlnode`"""
         self.xmlnode.set('id', self.id)
         self.xmlnode.set('name', self.id)
         colornode = self.xmlnode.find('%s/%s/%s' % (tag('technique_common'),
-            tag('directional'), tag('color')))
+                                                    tag('directional'), tag('color')))
         colornode.text = ' '.join(map(str, self.color))
-
 
     @staticmethod
     def load(collada, localscope, node):
-        colornode = node.find( '%s/%s/%s'%(collada.tag('technique_common'),collada.tag('directional'),
-                                           collada.tag('color') ) )
+        colornode = node.find('%s/%s/%s' % (collada.tag('technique_common'), collada.tag('directional'),
+                                            collada.tag('color')))
         if colornode is None:
             raise DaeIncompleteError('Missing color for directional light')
         try:
             color = tuple([float(v) for v in colornode.text.split()])
-        except ValueError as ex:
+        except ValueError:
             raise DaeMalformedError('Corrupted color values in light definition')
-        return DirectionalLight(node.get('id'), color, xmlnode = node)
+        return DirectionalLight(node.get('id'), color, xmlnode=node)
 
     def bind(self, matrix):
         """Binds this light to a transform matrix.
@@ -121,7 +118,7 @@ class DirectionalLight(Light):
 class AmbientLight(Light):
     """Ambient light as defined in COLLADA tag <ambient>."""
 
-    def __init__(self, id, color, xmlnode = None):
+    def __init__(self, id, color, xmlnode=None):
         """Create a new ambient light.
 
         :param str id:
@@ -140,7 +137,7 @@ class AmbientLight(Light):
         """Either a tuple of size 3 containing the RGB color value
           of the light or a tuple of size 4 containing the RGBA
           color value of the light"""
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the light."""
         else:
@@ -149,29 +146,27 @@ class AmbientLight(Light):
                     E.ambient(
                         E.color(' '.join(map(str, self.color)))
                     )
-                )
-            , id=self.id, name=self.id)
+                ), id=self.id, name=self.id)
 
     def save(self):
         """Saves the light's properties back to :attr:`xmlnode`"""
         self.xmlnode.set('id', self.id)
         self.xmlnode.set('name', self.id)
         colornode = self.xmlnode.find('%s/%s/%s' % (tag('technique_common'),
-            tag('ambient'), tag('color')))
+                                                    tag('ambient'), tag('color')))
         colornode.text = ' '.join(map(str, self.color))
-
 
     @staticmethod
     def load(collada, localscope, node):
         colornode = node.find('%s/%s/%s' % (collada.tag('technique_common'),
-            collada.tag('ambient'), collada.tag('color')))
+                                            collada.tag('ambient'), collada.tag('color')))
         if colornode is None:
             raise DaeIncompleteError('Missing color for ambient light')
         try:
-            color = tuple( [ float(v) for v in colornode.text.split() ] )
-        except ValueError as ex:
+            color = tuple([float(v) for v in colornode.text.split()])
+        except ValueError:
             raise DaeMalformedError('Corrupted color values in light definition')
-        return AmbientLight(node.get('id'), color, xmlnode = node)
+        return AmbientLight(node.get('id'), color, xmlnode=node)
 
     def bind(self, matrix):
         """Binds this light to a transform matrix.
@@ -195,7 +190,7 @@ class PointLight(Light):
     """Point light as defined in COLLADA tag <point>."""
 
     def __init__(self, id, color, constant_att=None, linear_att=None,
-            quad_att=None, zfar=None, xmlnode = None):
+                 quad_att=None, zfar=None, xmlnode=None):
         """Create a new sun light.
 
         :param str id:
@@ -218,8 +213,8 @@ class PointLight(Light):
         """
         self.id = id
         """The unique string identifier for the light"""
-        self.position = numpy.array( [0, 0, 0], dtype=numpy.float32 )
-        #Not documenting this because it doesn't make sense to set the position
+        self.position = numpy.array([0, 0, 0], dtype=numpy.float32)
+        # Not documenting this because it doesn't make sense to set the position
         # of an unbound light. The position isn't set until binding in a scene.
         self.color = color
         """Either a tuple of size 3 containing the RGB color value
@@ -234,12 +229,12 @@ class PointLight(Light):
         self.zfar = zfar
         """Distance to the far clipping plane"""
 
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the light."""
         else:
             pnode = E.point(
-                E.color(' '.join(map(str, self.color ) ))
+                E.color(' '.join(map(str, self.color)))
             )
             if self.constant_att is not None:
                 pnode.append(E.constant_attenuation(str(self.constant_att)))
@@ -251,16 +246,15 @@ class PointLight(Light):
                 pnode.append(E.zfar(str(self.zvar)))
 
             self.xmlnode = E.light(
-                E.technique_common(pnode)
-            , id=self.id, name=self.id)
+                E.technique_common(pnode), id=self.id, name=self.id)
 
     def save(self):
         """Saves the light's properties back to :attr:`xmlnode`"""
         self.xmlnode.set('id', self.id)
         self.xmlnode.set('name', self.id)
-        pnode = self.xmlnode.find( '%s/%s'%(tag('technique_common'), tag('point')) )
-        colornode = pnode.find( tag('color') )
-        colornode.text = ' '.join(map(str, self.color ) )
+        pnode = self.xmlnode.find('%s/%s' % (tag('technique_common'), tag('point')))
+        colornode = pnode.find(tag('color'))
+        colornode.text = ' '.join(map(str, self.color))
         _correctValInNode(pnode, 'constant_attenuation', self.constant_att)
         _correctValInNode(pnode, 'linear_attenuation', self.linear_att)
         _correctValInNode(pnode, 'quadratic_attenuation', self.quad_att)
@@ -269,18 +263,18 @@ class PointLight(Light):
     @staticmethod
     def load(collada, localscope, node):
         pnode = node.find('%s/%s' % (collada.tag('technique_common'), collada.tag('point')))
-        colornode = pnode.find( collada.tag('color') )
+        colornode = pnode.find(collada.tag('color'))
         if colornode is None:
             raise DaeIncompleteError('Missing color for point light')
         try:
             color = tuple([float(v) for v in colornode.text.split()])
-        except ValueError as ex:
+        except ValueError:
             raise DaeMalformedError('Corrupted color values in light definition')
         constant_att = linear_att = quad_att = zfar = None
-        qattnode = pnode.find( collada.tag('quadratic_attenuation') )
-        cattnode = pnode.find( collada.tag('constant_attenuation') )
-        lattnode = pnode.find( collada.tag('linear_attenuation') )
-        zfarnode = pnode.find( collada.tag('zfar') )
+        qattnode = pnode.find(collada.tag('quadratic_attenuation'))
+        cattnode = pnode.find(collada.tag('constant_attenuation'))
+        lattnode = pnode.find(collada.tag('linear_attenuation'))
+        zfarnode = pnode.find(collada.tag('zfar'))
         try:
             if cattnode is not None:
                 constant_att = float(cattnode.text)
@@ -290,10 +284,10 @@ class PointLight(Light):
                 quad_att = float(qattnode.text)
             if zfarnode is not None:
                 zfar = float(zfarnode.text)
-        except ValueError as ex:
+        except ValueError:
             raise DaeMalformedError('Corrupted values in light definition')
         return PointLight(node.get('id'), color, constant_att, linear_att,
-                quad_att, zfar, xmlnode = node)
+                          quad_att, zfar, xmlnode=node)
 
     def bind(self, matrix):
         """Binds this light to a transform matrix.
@@ -317,7 +311,7 @@ class SpotLight(Light):
     """Spot light as defined in COLLADA tag <spot>."""
 
     def __init__(self, id, color, constant_att=None, linear_att=None,
-            quad_att=None, falloff_ang=None, falloff_exp=None, xmlnode = None):
+                 quad_att=None, falloff_ang=None, falloff_exp=None, xmlnode=None):
         """Create a new spot light.
 
         :param str id:
@@ -357,12 +351,12 @@ class SpotLight(Light):
         self.falloff_exp = falloff_exp
         """Falloff exponent"""
 
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the light."""
         else:
             pnode = E.spot(
-                E.color(' '.join(map(str, self.color ) )),
+                E.color(' '.join(map(str, self.color))),
             )
             if self.constant_att is not None:
                 pnode.append(E.constant_attenuation(str(self.constant_att)))
@@ -376,8 +370,7 @@ class SpotLight(Light):
                 pnode.append(E.falloff_exponent(str(self.falloff_exp)))
 
             self.xmlnode = E.light(
-                E.technique_common(pnode)
-            , id=self.id, name=self.id)
+                E.technique_common(pnode), id=self.id, name=self.id)
 
     def save(self):
         """Saves the light's properties back to :attr:`xmlnode`"""
@@ -385,7 +378,7 @@ class SpotLight(Light):
         self.xmlnode.set('name', self.id)
         pnode = self.xmlnode.find('%s/%s' % (tag('technique_common'), tag('spot')))
         colornode = pnode.find(tag('color'))
-        colornode.text = ' '.join(map(str, self.color ) )
+        colornode.text = ' '.join(map(str, self.color))
         _correctValInNode(pnode, 'constant_attenuation', self.constant_att)
         _correctValInNode(pnode, 'linear_attenuation', self.linear_att)
         _correctValInNode(pnode, 'quadratic_attenuation', self.quad_att)
@@ -394,20 +387,20 @@ class SpotLight(Light):
 
     @staticmethod
     def load(collada, localscope, node):
-        pnode = node.find( '%s/%s'%(collada.tag('technique_common'),collada.tag('spot')) )
-        colornode = pnode.find( collada.tag('color') )
+        pnode = node.find('%s/%s' % (collada.tag('technique_common'), collada.tag('spot')))
+        colornode = pnode.find(collada.tag('color'))
         if colornode is None:
             raise DaeIncompleteError('Missing color for spot light')
         try:
             color = tuple([float(v) for v in colornode.text.split()])
-        except ValueError as ex:
+        except ValueError:
             raise DaeMalformedError('Corrupted color values in spot light definition')
         constant_att = linear_att = quad_att = falloff_ang = falloff_exp = None
-        cattnode = pnode.find( collada.tag('constant_attenuation') )
-        lattnode = pnode.find( collada.tag('linear_attenuation') )
-        qattnode = pnode.find( collada.tag('quadratic_attenuation') )
-        fangnode = pnode.find( collada.tag('falloff_angle') )
-        fexpnode = pnode.find( collada.tag('falloff_exponent') )
+        cattnode = pnode.find(collada.tag('constant_attenuation'))
+        lattnode = pnode.find(collada.tag('linear_attenuation'))
+        qattnode = pnode.find(collada.tag('quadratic_attenuation'))
+        fangnode = pnode.find(collada.tag('falloff_angle'))
+        fexpnode = pnode.find(collada.tag('falloff_exponent'))
         try:
             if cattnode is not None:
                 constant_att = float(cattnode.text)
@@ -419,10 +412,10 @@ class SpotLight(Light):
                 falloff_ang = float(fangnode.text)
             if fexpnode is not None:
                 falloff_exp = float(fexpnode.text)
-        except ValueError as ex:
+        except ValueError:
             raise DaeMalformedError('Corrupted values in spot light definition')
         return SpotLight(node.get('id'), color, constant_att, linear_att,
-                quad_att, falloff_ang, falloff_exp, xmlnode = node)
+                         quad_att, falloff_ang, falloff_exp, xmlnode=node)
 
     def bind(self, matrix):
         """Binds this light to a transform matrix.
@@ -444,7 +437,6 @@ class SpotLight(Light):
 
 class BoundLight(object):
     """Base class for bound lights"""
-    pass
 
 
 class BoundPointLight(BoundLight):
@@ -452,7 +444,7 @@ class BoundPointLight(BoundLight):
         light is instantiated in a scene. Do not create this manually."""
 
     def __init__(self, plight, matrix):
-        self.position = numpy.dot( matrix[:3,:3], plight.position ) + matrix[:3,3]
+        self.position = numpy.dot(matrix[:3, :3], plight.position) + matrix[:3, 3]
         """Numpy array of length 3 representing the position of the light in the scene"""
         self.color = plight.color
         """Either a tuple of size 3 containing the RGB color value
@@ -487,11 +479,11 @@ class BoundSpotLight(BoundLight):
         light is instantiated in a scene. Do not create this manually."""
 
     def __init__(self, slight, matrix):
-        self.position = matrix[:3,3]
+        self.position = matrix[:3, 3]
         """Numpy array of length 3 representing the position of the light in the scene"""
-        self.direction = -matrix[:3,2]
+        self.direction = -matrix[:3, 2]
         """Direction of the spot light"""
-        self.up = matrix[:3,1]
+        self.up = matrix[:3, 1]
         """Up vector of the spot light"""
         self.matrix = matrix
         """Transform matrix for the bound light"""
@@ -528,12 +520,13 @@ class BoundSpotLight(BoundLight):
     def __repr__(self):
         return str(self)
 
+
 class BoundDirectionalLight(BoundLight):
     """Directional light bound to a scene with transformation. This gets created when a
         light is instantiated in a scene. Do not create this manually."""
 
     def __init__(self, dlight, matrix):
-        self.direction = numpy.dot( matrix[:3,:3], dlight.direction )
+        self.direction = numpy.dot(matrix[:3, :3], dlight.direction)
         """Numpy array of length 3 representing the direction of the light in the scene"""
         self.color = dlight.color
         """Either a tuple of size 3 containing the RGB color value
@@ -547,6 +540,7 @@ class BoundDirectionalLight(BoundLight):
 
     def __repr__(self):
         return str(self)
+
 
 class BoundAmbientLight(BoundLight):
     """Ambient light bound to a scene with transformation. This gets created when a
@@ -565,4 +559,3 @@ class BoundAmbientLight(BoundLight):
 
     def __repr__(self):
         return str(self)
-

--- a/collada/lineset.py
+++ b/collada/lineset.py
@@ -126,7 +126,6 @@ class LineSet(primitive.Primitive):
             """ElementTree representation of the line set."""
         else:
             self.index.shape = (-1)
-            len(self.index)
             txtindices = ' '.join(map(str, self.index.tolist()))
             self.index.shape = (-1, 2, self.nindices)
 

--- a/collada/polygons.py
+++ b/collada/polygons.py
@@ -16,12 +16,8 @@ import numpy
 
 from collada import primitive
 from collada import polylist
-from collada import triangleset
-from collada.common import E, tag
-from collada.common import DaeIncompleteError, DaeBrokenRefError, \
-        DaeMalformedError, DaeUnsupportedError
-from collada.util import toUnitVec, checkSource
-from collada.xmlutil import etree as ElementTree
+from collada.common import E
+from collada.common import DaeIncompleteError
 
 
 class Polygons(polylist.Polylist):
@@ -42,9 +38,9 @@ class Polygons(polylist.Polylist):
         creating a geometry instance.
         """
 
-        max_offset = max([ max([input[0] for input in input_type_array])
-            for input_type_array in sources.values()
-            if len(input_type_array) > 0])
+        max_offset = max([max([input[0] for input in input_type_array])
+                          for input_type_array in sources.values()
+                          if len(input_type_array) > 0])
 
         vcounts = numpy.zeros(len(polygons), dtype=numpy.int32)
         for i, poly in enumerate(polygons):
@@ -57,7 +53,8 @@ class Polygons(polylist.Polylist):
 
         super(Polygons, self).__init__(sources, material, indices, vcounts, xmlnode)
 
-        if xmlnode is not None: self.xmlnode = xmlnode
+        if xmlnode is not None:
+            self.xmlnode = xmlnode
         else:
             acclen = len(polygons)
 
@@ -78,9 +75,10 @@ class Polygons(polylist.Polylist):
                 self.xmlnode.append(E.p(' '.join(map(str, poly.flatten().tolist()))))
 
     @staticmethod
-    def load( collada, localscope, node ):
+    def load(collada, localscope, node):
         indexnodes = node.findall(collada.tag('p'))
-        if indexnodes is None: raise DaeIncompleteError('Missing indices in polygons')
+        if indexnodes is None:
+            raise DaeIncompleteError('Missing indices in polygons')
 
         polygon_indices = []
         for indexnode in indexnodes:
@@ -95,7 +93,7 @@ class Polygons(polylist.Polylist):
 
     def bind(self, matrix, materialnodebysymbol):
         """Create a bound polygons from this polygons, transform and material mapping"""
-        return BoundPolygons( self, matrix, materialnodebysymbol )
+        return BoundPolygons(self, matrix, materialnodebysymbol)
 
     def __str__(self):
         return '<Polygons length=%d>' % len(self)
@@ -116,4 +114,3 @@ class BoundPolygons(polylist.BoundPolylist):
 
     def __repr__(self):
         return str(self)
-

--- a/collada/polylist.py
+++ b/collada/polylist.py
@@ -188,7 +188,6 @@ class Polylist(primitive.Primitive):
             """ElementTree representation of the line set."""
         else:
             txtindices = ' '.join(map(str, self.indices.flatten().tolist()))
-            len(self.indices)
 
             self.xmlnode = E.polylist(count=str(self.npolygons))
             if self.material is not None:

--- a/collada/polylist.py
+++ b/collada/polylist.py
@@ -16,15 +16,14 @@ import numpy
 
 from collada import primitive
 from collada import triangleset
-from collada.common import E, tag
-from collada.common import DaeIncompleteError, DaeBrokenRefError, \
-        DaeMalformedError, DaeUnsupportedError
-from collada.util import toUnitVec, checkSource, xrange
-from collada.xmlutil import etree as ElementTree
+from collada.common import E
+from collada.common import DaeIncompleteError, DaeMalformedError
+from collada.util import checkSource, xrange
 
 
 class Polygon(object):
     """Single polygon representation. Represents a polygon of N points."""
+
     def __init__(self, indices, vertices, normal_indices, normals, texcoord_indices, texcoords, material):
         """A Polygon should not be created manually."""
 
@@ -59,28 +58,28 @@ class Polygon(object):
 
         npts = len(self.vertices)
 
-        for i in range(npts-2):
+        for i in range(npts - 2):
 
             tri_indices = numpy.array([
-                self.indices[0], self.indices[i+1], self.indices[i+2]
-                ], dtype=numpy.float32)
+                self.indices[0], self.indices[i + 1], self.indices[i + 2]
+            ], dtype=numpy.float32)
 
             tri_vertices = numpy.array([
-                self.vertices[0], self.vertices[i+1], self.vertices[i+2]
-                ], dtype=numpy.float32)
+                self.vertices[0], self.vertices[i + 1], self.vertices[i + 2]
+            ], dtype=numpy.float32)
 
             if self.normals is None:
                 tri_normals = None
                 normal_indices = None
             else:
                 tri_normals = numpy.array([
-                    self.normals[0], self.normals[i+1], self.normals[i+2]
-                    ], dtype=numpy.float32)
+                    self.normals[0], self.normals[i + 1], self.normals[i + 2]
+                ], dtype=numpy.float32)
                 normal_indices = numpy.array([
                     self.normal_indices[0],
-                    self.normal_indices[i+1],
-                    self.normal_indices[i+2]
-                    ], dtype=numpy.float32)
+                    self.normal_indices[i + 1],
+                    self.normal_indices[i + 2]
+                ], dtype=numpy.float32)
 
             tri_texcoords = []
             tri_texcoord_indices = []
@@ -88,20 +87,20 @@ class Polygon(object):
                     self.texcoords, self.texcoord_indices):
                 tri_texcoords.append(numpy.array([
                     texcoord[0],
-                    texcoord[i+1],
-                    texcoord[i+2]
-                    ], dtype=numpy.float32))
+                    texcoord[i + 1],
+                    texcoord[i + 2]
+                ], dtype=numpy.float32))
                 tri_texcoord_indices.append(numpy.array([
                     texcoord_indices[0],
-                    texcoord_indices[i+1],
-                    texcoord_indices[i+2]
-                    ], dtype=numpy.float32))
+                    texcoord_indices[i + 1],
+                    texcoord_indices[i + 2]
+                ], dtype=numpy.float32))
 
             tri = triangleset.Triangle(
-                    tri_indices, tri_vertices,
-                    normal_indices, tri_normals,
-                    tri_texcoord_indices, tri_texcoords,
-                    self.material)
+                tri_indices, tri_vertices,
+                normal_indices, tri_normals,
+                tri_texcoord_indices, tri_texcoords,
+                self.material)
             yield tri
 
     def __repr__(self):
@@ -127,11 +126,13 @@ class Polylist(primitive.Primitive):
         creating a geometry instance.
         """
 
-        if len(sources) == 0: raise DaeIncompleteError('A polylist set needs at least one input for vertex positions')
-        if not 'VERTEX' in sources: raise DaeIncompleteError('Polylist requires vertex input')
+        if len(sources) == 0:
+            raise DaeIncompleteError('A polylist set needs at least one input for vertex positions')
+        if 'VERTEX' not in sources:
+            raise DaeIncompleteError('Polylist requires vertex input')
 
-        #find max offset
-        max_offset = max([ max([input[0] for input in input_type_array])
+        # find max offset
+        max_offset = max([max([input[0] for input in input_type_array])
                           for input_type_array in sources.values() if len(input_type_array) > 0])
 
         self.material = material
@@ -149,8 +150,8 @@ class Polylist(primitive.Primitive):
 
         if len(self.index) > 0:
             self._vertex = sources['VERTEX'][0][4].data
-            self._vertex_index = self.index[:,sources['VERTEX'][0][0]]
-            self.maxvertexindex = numpy.max( self._vertex_index )
+            self._vertex_index = self.index[:, sources['VERTEX'][0][0]]
+            self.maxvertexindex = numpy.max(self._vertex_index)
             checkSource(sources['VERTEX'][0][4], ('X', 'Y', 'Z'), self.maxvertexindex)
         else:
             self._vertex = None
@@ -159,8 +160,8 @@ class Polylist(primitive.Primitive):
 
         if 'NORMAL' in sources and len(sources['NORMAL']) > 0 and len(self.index) > 0:
             self._normal = sources['NORMAL'][0][4].data
-            self._normal_index = self.index[:,sources['NORMAL'][0][0]]
-            self.maxnormalindex = numpy.max( self._normal_index )
+            self._normal_index = self.index[:, sources['NORMAL'][0][0]]
+            self.maxnormalindex = numpy.max(self._normal_index)
             checkSource(sources['NORMAL'][0][4], ('X', 'Y', 'Z'), self.maxnormalindex)
         else:
             self._normal = None
@@ -170,11 +171,11 @@ class Polylist(primitive.Primitive):
         if 'TEXCOORD' in sources and len(sources['TEXCOORD']) > 0 \
                 and len(self.index) > 0:
             self._texcoordset = tuple([texinput[4].data
-                for texinput in sources['TEXCOORD']])
-            self._texcoord_indexset = tuple([ self.index[:,sources['TEXCOORD'][i][0]]
-                for i in xrange(len(sources['TEXCOORD'])) ])
+                                       for texinput in sources['TEXCOORD']])
+            self._texcoord_indexset = tuple([self.index[:, sources['TEXCOORD'][i][0]]
+                                             for i in xrange(len(sources['TEXCOORD']))])
             self.maxtexcoordsetindex = [numpy.max(each)
-                for each in self._texcoord_indexset]
+                                        for each in self._texcoord_indexset]
             for i, texinput in enumerate(sources['TEXCOORD']):
                 checkSource(texinput[4], ('S', 'T'), self.maxtexcoordsetindex[i])
         else:
@@ -187,7 +188,7 @@ class Polylist(primitive.Primitive):
             """ElementTree representation of the line set."""
         else:
             txtindices = ' '.join(map(str, self.indices.flatten().tolist()))
-            acclen = len(self.indices)
+            len(self.indices)
 
             self.xmlnode = E.polylist(count=str(self.npolygons))
             if self.material is not None:
@@ -198,7 +199,7 @@ class Polylist(primitive.Primitive):
                 all_inputs.extend(semantic_list)
             for offset, semantic, sourceid, set, src in all_inputs:
                 inpnode = E.input(offset=str(offset), semantic=semantic,
-                        source=sourceid)
+                                  source=sourceid)
                 if set is not None:
                     inpnode.set('set', str(set))
                 self.xmlnode.append(inpnode)
@@ -225,12 +226,13 @@ class Polylist(primitive.Primitive):
         uvindices = []
         uv = []
         for j, uvindex in enumerate(self._texcoord_indexset):
-            uvindices.append( uvindex[polyrange[0]:polyrange[1]] )
-            uv.append( self._texcoordset[j][ uvindex[polyrange[0]:polyrange[1]] ] )
+            uvindices.append(uvindex[polyrange[0]:polyrange[1]])
+            uv.append(self._texcoordset[j][uvindex[polyrange[0]:polyrange[1]]])
 
         return Polygon(vertindex, v, normalindex, n, uvindices, uv, self.material)
 
     _triangleset = None
+
     def triangleset(self):
         """This performs a simple triangulation of the polylist using the fanning method.
 
@@ -239,8 +241,8 @@ class Polylist(primitive.Primitive):
 
         if self._triangleset is None:
             indexselector = numpy.zeros(self.nvertices) == 0
-            indexselector[self.polyindex[:,1]-1] = False
-            indexselector[self.polyindex[:,1]-2] = False
+            indexselector[self.polyindex[:, 1] - 1] = False
+            indexselector[self.polyindex[:, 1] - 2] = False
             indexselector = numpy.arange(self.nvertices)[indexselector]
 
             firstpolyindex = numpy.arange(self.nvertices)
@@ -248,10 +250,10 @@ class Polylist(primitive.Primitive):
             firstpolyindex = firstpolyindex[indexselector]
 
             if len(self.index) > 0:
-                triindex = numpy.dstack( (self.index[indexselector-firstpolyindex],
-                                          self.index[indexselector+1],
-                                          self.index[indexselector+2]) )
-                triindex = numpy.swapaxes(triindex, 1,2).flatten()
+                triindex = numpy.dstack((self.index[indexselector - firstpolyindex],
+                                         self.index[indexselector + 1],
+                                         self.index[indexselector + 2]))
+                triindex = numpy.swapaxes(triindex, 1, 2).flatten()
             else:
                 triindex = numpy.array([], dtype=self.index.dtype)
 
@@ -261,11 +263,13 @@ class Polylist(primitive.Primitive):
         return self._triangleset
 
     @staticmethod
-    def load( collada, localscope, node ):
+    def load(collada, localscope, node):
         indexnode = node.find(collada.tag('p'))
-        if indexnode is None: raise DaeIncompleteError('Missing index in polylist')
+        if indexnode is None:
+            raise DaeIncompleteError('Missing index in polylist')
         vcountnode = node.find(collada.tag('vcount'))
-        if vcountnode is None: raise DaeIncompleteError('Missing vcount in polylist')
+        if vcountnode is None:
+            raise DaeIncompleteError('Missing vcount in polylist')
 
         try:
             if vcountnode.text is None or vcountnode.text.isspace():
@@ -273,7 +277,7 @@ class Polylist(primitive.Primitive):
             else:
                 vcounts = numpy.fromstring(vcountnode.text, dtype=numpy.int32, sep=' ')
             vcounts[numpy.isnan(vcounts)] = 0
-        except ValueError as ex:
+        except ValueError:
             raise DaeMalformedError('Corrupted vcounts in polylist')
 
         all_inputs = primitive.Primitive._getInputs(collada, localscope, node.findall(collada.tag('input')))
@@ -284,14 +288,15 @@ class Polylist(primitive.Primitive):
             else:
                 index = numpy.fromstring(indexnode.text, dtype=numpy.int32, sep=' ')
             index[numpy.isnan(index)] = 0
-        except: raise DaeMalformedError('Corrupted index in polylist')
+        except BaseException:
+            raise DaeMalformedError('Corrupted index in polylist')
 
         polylist = Polylist(all_inputs, node.get('material'), index, vcounts, node)
         return polylist
 
     def bind(self, matrix, materialnodebysymbol):
         """Create a bound polylist from this polylist, transform and material mapping"""
-        return BoundPolylist( self, matrix, materialnodebysymbol)
+        return BoundPolylist(self, matrix, materialnodebysymbol)
 
     def __str__(self):
         return '<Polylist length=%d>' % len(self)
@@ -312,14 +317,15 @@ class BoundPolylist(primitive.BoundPrimitive):
         """Create a bound polylist from a polylist, transform and material mapping.
         This gets created when a polylist is instantiated in a scene. Do not create this manually."""
         M = numpy.asmatrix(matrix).transpose()
-        self._vertex = None if pl._vertex is None else numpy.asarray(pl._vertex * M[:3,:3]) + matrix[:3,3]
-        self._normal = None if pl._normal is None else numpy.asarray(pl._normal * M[:3,:3])
+        self._vertex = None if pl._vertex is None else numpy.asarray(pl._vertex * M[:3, :3]) + matrix[:3, 3]
+        self._normal = None if pl._normal is None else numpy.asarray(pl._normal * M[:3, :3])
         self._texcoordset = pl._texcoordset
-        matnode = materialnodebysymbol.get( pl.material )
+        matnode = materialnodebysymbol.get(pl.material)
         if matnode:
             self.material = matnode.target
-            self.inputmap = dict([ (sem, (input_sem, set)) for sem, input_sem, set in matnode.inputs ])
-        else: self.inputmap = self.material = None
+            self.inputmap = dict([(sem, (input_sem, set)) for sem, input_sem, set in matnode.inputs])
+        else:
+            self.inputmap = self.material = None
         self.index = pl.index
         self.nvertices = pl.nvertices
         self._vertex_index = pl._vertex_index
@@ -331,7 +337,8 @@ class BoundPolylist(primitive.BoundPrimitive):
         self.materialnodebysymbol = materialnodebysymbol
         self.original = pl
 
-    def __len__(self): return self.npolygons
+    def __len__(self):
+        return self.npolygons
 
     def __getitem__(self, i):
         polyrange = self.polyindex[i]
@@ -348,12 +355,13 @@ class BoundPolylist(primitive.BoundPrimitive):
         uvindices = []
         uv = []
         for j, uvindex in enumerate(self._texcoord_indexset):
-            uvindices.append( uvindex[polyrange[0]:polyrange[1]] )
-            uv.append( self._texcoordset[j][ uvindex[polyrange[0]:polyrange[1]] ] )
+            uvindices.append(uvindex[polyrange[0]:polyrange[1]])
+            uv.append(self._texcoordset[j][uvindex[polyrange[0]:polyrange[1]]])
 
         return Polygon(vertindex, v, normalindex, n, uvindices, uv, self.material)
 
     _triangleset = None
+
     def triangleset(self):
         """This performs a simple triangulation of the polylist using the fanning method.
 
@@ -370,7 +378,8 @@ class BoundPolylist(primitive.BoundPrimitive):
 
         :rtype: generator of :class:`collada.polylist.Polygon`
         """
-        for i in xrange(self.npolygons): yield self[i]
+        for i in xrange(self.npolygons):
+            yield self[i]
 
     def shapes(self):
         """Iterate through all the polygons contained in the set.
@@ -384,4 +393,3 @@ class BoundPolylist(primitive.BoundPrimitive):
 
     def __repr__(self):
         return str(self)
-

--- a/collada/primitive.py
+++ b/collada/primitive.py
@@ -11,59 +11,48 @@
 ####################################################################
 
 """Module containing the base class for primitives"""
-import numpy
-import types
 
 from collada.common import DaeObject
-from collada.common import DaeIncompleteError, DaeBrokenRefError, \
-        DaeMalformedError, DaeUnsupportedError
+from collada.common import DaeBrokenRefError, DaeMalformedError, \
+    DaeUnsupportedError
 from collada.source import InputList
+
 
 class Primitive(DaeObject):
     """Base class for all primitive sets like TriangleSet, LineSet, Polylist, etc."""
 
-    vertex = property( lambda s: s._vertex, doc=
-    """Read-only numpy.array of size Nx3 where N is the number of vertex points in the
-    primitive's vertex source array.""" )
-    normal = property( lambda s: s._normal, doc=
-    """Read-only numpy.array of size Nx3 where N is the number of normal values in the
-    primitive's normal source array.""" )
-    texcoordset = property( lambda s: s._texcoordset, doc=
-    """Read-only tuple of texture coordinate arrays. Each value is a numpy.array of size
-    Nx2 where N is the number of texture coordinates in the primitive's source array.""" )
-    textangentset = property( lambda s: s._textangentset, doc=
-    """Read-only tuple of texture tangent arrays. Each value is a numpy.array of size
-    Nx3 where N is the number of texture tangents in the primitive's source array.""" )
-    texbinormalset = property( lambda s: s._texbinormalset, doc=
-    """Read-only tuple of texture binormal arrays. Each value is a numpy.array of size
-    Nx3 where N is the number of texture binormals in the primitive's source array.""" )
+    vertex = property(lambda s: s._vertex, doc="""Read-only numpy.array of size Nx3 where N is the number of vertex points in the
+    primitive's vertex source array.""")
+    normal = property(lambda s: s._normal, doc="""Read-only numpy.array of size Nx3 where N is the number of normal values in the
+    primitive's normal source array.""")
+    texcoordset = property(lambda s: s._texcoordset, doc="""Read-only tuple of texture coordinate arrays. Each value is a numpy.array of size
+    Nx2 where N is the number of texture coordinates in the primitive's source array.""")
+    textangentset = property(lambda s: s._textangentset, doc="""Read-only tuple of texture tangent arrays. Each value is a numpy.array of size
+    Nx3 where N is the number of texture tangents in the primitive's source array.""")
+    texbinormalset = property(lambda s: s._texbinormalset, doc="""Read-only tuple of texture binormal arrays. Each value is a numpy.array of size
+    Nx3 where N is the number of texture binormals in the primitive's source array.""")
 
-    vertex_index = property( lambda s: s._vertex_index, doc=
-    """Read-only numpy.array of size Nx3 where N is the number of vertices in the primitive.
+    vertex_index = property(lambda s: s._vertex_index, doc="""Read-only numpy.array of size Nx3 where N is the number of vertices in the primitive.
     To get the actual vertex points, one can use this array to select into the vertex
-    array, e.g. ``vertex[vertex_index]``.""" )
-    normal_index = property( lambda s: s._normal_index, doc=
-    """Read-only numpy.array of size Nx3 where N is the number of vertices in the primitive.
+    array, e.g. ``vertex[vertex_index]``.""")
+    normal_index = property(lambda s: s._normal_index, doc="""Read-only numpy.array of size Nx3 where N is the number of vertices in the primitive.
     To get the actual normal values, one can use this array to select into the normals
-    array, e.g. ``normal[normal_index]``.""" )
-    texcoord_indexset = property( lambda s: s._texcoord_indexset, doc=
-    """Read-only tuple of texture coordinate index arrays. Each value is a numpy.array of size
+    array, e.g. ``normal[normal_index]``.""")
+    texcoord_indexset = property(lambda s: s._texcoord_indexset, doc="""Read-only tuple of texture coordinate index arrays. Each value is a numpy.array of size
     Nx2 where N is the number of vertices in the primitive. To get the actual texture
     coordinates, one can use the array to select into the texcoordset array, e.g.
     ``texcoordset[0][texcoord_indexset[0]]`` would select the first set of texture
-    coordinates.""" )
-    textangent_indexset = property( lambda s: s._textangent_indexset, doc=
-    """Read-only tuple of texture tangent index arrays. Each value is a numpy.array of size
+    coordinates.""")
+    textangent_indexset = property(lambda s: s._textangent_indexset, doc="""Read-only tuple of texture tangent index arrays. Each value is a numpy.array of size
     Nx3 where N is the number of vertices in the primitive. To get the actual texture
     tangents, one can use the array to select into the textangentset array, e.g.
     ``textangentset[0][textangent_indexset[0]]`` would select the first set of texture
-    tangents.""" )
-    texbinormal_indexset = property( lambda s: s._texbinormal_indexset, doc=
-    """Read-only tuple of texture binormal index arrays. Each value is a numpy.array of size
+    tangents.""")
+    texbinormal_indexset = property(lambda s: s._texbinormal_indexset, doc="""Read-only tuple of texture binormal index arrays. Each value is a numpy.array of size
     Nx3 where N is the number of vertices in the primitive. To get the actual texture
     binormals, one can use the array to select into the texbinormalset array, e.g.
     ``texbinormalset[0][texbinormal_indexset[0]]`` would select the first set of texture
-    binormals.""" )
+    binormals.""")
 
     def bind(self, matrix, materialnodebysymbol):
         """Binds this primitive to a transform matrix and material mapping.
@@ -80,11 +69,10 @@ class Primitive(DaeObject):
         :rtype: :class:`collada.primitive.Primitive`
 
         """
-        pass
 
     @staticmethod
     def _getInputsFromList(collada, localscope, inputs):
-        #first let's save any of the source that are references to a dict
+        # first let's save any of the source that are references to a dict
         to_append = []
         for input in inputs:
             offset, semantic, source, set = input
@@ -97,11 +85,11 @@ class Primitive(DaeObject):
                         else:
                             to_append.append([offset, inputsemantic, '#' + inputsource.id, set])
 
-        #remove all the dicts
+        # remove all the dicts
         inputs[:] = [input for input in inputs
-                if not isinstance(localscope.get(input[2][1:]), dict)]
+                     if not isinstance(localscope.get(input[2][1:]), dict)]
 
-        #append the dereferenced dicts
+        # append the dereferenced dicts
         for a in to_append:
             inputs.append(a)
 
@@ -163,9 +151,9 @@ class Primitive(DaeObject):
     def _getInputs(collada, localscope, inputnodes):
         try:
             inputs = [(int(i.get('offset')), i.get('semantic'),
-                    i.get('source'), i.get('set'))
-                for i in inputnodes]
-        except ValueError as ex:
+                       i.get('source'), i.get('set'))
+                      for i in inputnodes]
+        except ValueError:
             raise DaeMalformedError('Corrupted offsets in primitive')
 
         return Primitive._getInputsFromList(collada, localscope, inputs)
@@ -181,6 +169,7 @@ class Primitive(DaeObject):
     def save(self):
         return NotImplementedError("Primitives are read-only")
 
+
 class BoundPrimitive(object):
     """A :class:`collada.primitive.Primitive` bound to a transform matrix
     and material mapping."""
@@ -188,33 +177,26 @@ class BoundPrimitive(object):
     def shapes(self):
         """Iterate through the items in this primitive. The shape returned
         depends on the primitive type. Examples: Triangle, Polygon."""
-        pass
 
-    vertex = property( lambda s: s._vertex, doc=
-    """Read-only numpy.array of size Nx3 where N is the number of vertex points in the
+    vertex = property(lambda s: s._vertex, doc="""Read-only numpy.array of size Nx3 where N is the number of vertex points in the
     primitive's vertex source array. The values will be transformed according to the
-    bound transformation matrix.""" )
-    normal = property( lambda s: s._normal, doc=
-    """Read-only numpy.array of size Nx3 where N is the number of normal values in the
+    bound transformation matrix.""")
+    normal = property(lambda s: s._normal, doc="""Read-only numpy.array of size Nx3 where N is the number of normal values in the
     primitive's normal source array. The values will be transformed according to the
-    bound transformation matrix.""" )
-    texcoordset = property( lambda s: s._texcoordset, doc=
-    """Read-only tuple of texture coordinate arrays. Each value is a numpy.array of size
+    bound transformation matrix.""")
+    texcoordset = property(lambda s: s._texcoordset, doc="""Read-only tuple of texture coordinate arrays. Each value is a numpy.array of size
     Nx2 where N is the number of texture coordinates in the primitive's source array. The
-    values will be transformed according to the bound transformation matrix.""" )
-    vertex_index = property( lambda s: s._vertex_index, doc=
-    """Read-only numpy.array of size Nx3 where N is the number of vertices in the primitive.
+    values will be transformed according to the bound transformation matrix.""")
+    vertex_index = property(lambda s: s._vertex_index, doc="""Read-only numpy.array of size Nx3 where N is the number of vertices in the primitive.
     To get the actual vertex points, one can use this array to select into the vertex
     array, e.g. ``vertex[vertex_index]``. The values will be transformed according to the
-    bound transformation matrix.""" )
-    normal_index = property( lambda s: s._normal_index, doc=
-    """Read-only numpy.array of size Nx3 where N is the number of vertices in the primitive.
+    bound transformation matrix.""")
+    normal_index = property(lambda s: s._normal_index, doc="""Read-only numpy.array of size Nx3 where N is the number of vertices in the primitive.
     To get the actual normal values, one can use this array to select into the normals
     array, e.g. ``normal[normal_index]``. The values will be transformed according to the
-    bound transformation matrix.""" )
-    texcoord_indexset = property( lambda s: s._texcoord_indexset, doc=
-    """Read-only tuple of texture coordinate index arrays. Each value is a numpy.array of size
+    bound transformation matrix.""")
+    texcoord_indexset = property(lambda s: s._texcoord_indexset, doc="""Read-only tuple of texture coordinate index arrays. Each value is a numpy.array of size
     Nx2 where N is the number of vertices in the primitive. To get the actual texture
     coordinates, one can use the array to select into the texcoordset array, e.g.
     ``texcoordset[0][texcoord_indexset[0]]`` would select the first set of texture
-    coordinates. The values will be transformed according to the bound transformation matrix.""" )
+    coordinates. The values will be transformed according to the bound transformation matrix.""")

--- a/collada/scene.py
+++ b/collada/scene.py
@@ -39,8 +39,9 @@ from collada.xmlutil import etree as ElementTree
 
 class DaeInstanceNotLoadedError(Exception):
     """Raised when an instance_node refers to a node that isn't loaded yet. Will always be caught"""
+
     def __init__(self, msg):
-        super(DaeInstanceNotLoadedError,self).__init__()
+        super(DaeInstanceNotLoadedError, self).__init__()
         self.msg = msg
 
 
@@ -60,7 +61,6 @@ class SceneNode(DaeObject):
         :rtype: generator that yields the type specified
 
         """
-        pass
 
 
 def makeRotationMatrix(x, y, z, angle):
@@ -68,12 +68,12 @@ def makeRotationMatrix(x, y, z, angle):
     around (`x`,`y`,`z`) axis."""
     c = numpy.cos(angle)
     s = numpy.sin(angle)
-    t = (1-c)
-    return numpy.array([[t*x*x+c,     t*x*y - s*z, t*x*z + s*y, 0],
-                        [t*x*y+s*z,   t*y*y + c,   t*y*z - s*x, 0],
-                        [t*x*z - s*y, t*y*z + s*x, t*z*z + c,   0],
-                        [0,           0,           0,           1]],
-                       dtype=numpy.float32 )
+    t = (1 - c)
+    return numpy.array([[t * x * x + c, t * x * y - s * z, t * x * z + s * y, 0],
+                        [t * x * y + s * z, t * y * y + c, t * y * z - s * x, 0],
+                        [t * x * z - s * y, t * y * z + s * x, t * z * z + c, 0],
+                        [0, 0, 0, 1]],
+                       dtype=numpy.float32)
 
 
 class Transform(DaeObject):
@@ -107,11 +107,11 @@ class TranslateTransform(Transform):
         """z coordinate"""
         self.matrix = numpy.identity(4, dtype=numpy.float32)
         """The resulting transformation matrix. This will be a numpy.array of size 4x4."""
-        self.matrix[:3,3] = [ x, y, z ]
+        self.matrix[:3, 3] = [x, y, z]
         self.xmlnode = xmlnode
         """ElementTree representation of the transform."""
         if xmlnode is None:
-            self.xmlnode = E.translate(' '.join([str(x),str(y),str(z)]))
+            self.xmlnode = E.translate(' '.join([str(x), str(y), str(z)]))
 
     @staticmethod
     def load(collada, node):
@@ -153,12 +153,12 @@ class RotateTransform(Transform):
         """z coordinate"""
         self.angle = angle
         """angle of rotation, in degrees"""
-        self.matrix = makeRotationMatrix(x, y, z, angle*numpy.pi/180.0)
+        self.matrix = makeRotationMatrix(x, y, z, angle * numpy.pi / 180.0)
         """The resulting transformation matrix. This will be a numpy.array of size 4x4."""
         self.xmlnode = xmlnode
         """ElementTree representation of the transform."""
         if xmlnode is None:
-            self.xmlnode = E.rotate(' '.join([str(x),str(y),str(z),str(angle)]))
+            self.xmlnode = E.rotate(' '.join([str(x), str(y), str(z), str(angle)]))
 
     @staticmethod
     def load(collada, node):
@@ -198,13 +198,13 @@ class ScaleTransform(Transform):
         """z coordinate"""
         self.matrix = numpy.identity(4, dtype=numpy.float32)
         """The resulting transformation matrix. This will be a numpy.array of size 4x4."""
-        self.matrix[0,0] = x
-        self.matrix[1,1] = y
-        self.matrix[2,2] = z
+        self.matrix[0, 0] = x
+        self.matrix[1, 1] = y
+        self.matrix[2, 2] = z
         self.xmlnode = xmlnode
         """ElementTree representation of the transform."""
         if xmlnode is None:
-            self.xmlnode = E.scale(' '.join([str(x),str(y),str(z)]))
+            self.xmlnode = E.scale(' '.join([str(x), str(y), str(z)]))
 
     @staticmethod
     def load(collada, node):
@@ -234,7 +234,8 @@ class MatrixTransform(Transform):
         """
         self.matrix = matrix
         """The resulting transformation matrix. This will be a numpy.array of size 4x4."""
-        if len(self.matrix) != 16: raise DaeMalformedError('Corrupted matrix transformation node')
+        if len(self.matrix) != 16:
+            raise DaeMalformedError('Corrupted matrix transformation node')
         self.matrix.shape = (4, 4)
         self.xmlnode = xmlnode
         """ElementTree representation of the transform."""
@@ -282,18 +283,19 @@ class LookAtTransform(Transform):
         self.matrix = numpy.identity(4, dtype=numpy.float32)
         """The resulting transformation matrix. This will be a numpy.array of size 4x4."""
 
-        front = toUnitVec(numpy.subtract(eye,interest))
+        front = toUnitVec(numpy.subtract(eye, interest))
         side = numpy.multiply(-1, toUnitVec(numpy.cross(front, upvector)))
-        self.matrix[0,0:3] = side
-        self.matrix[1,0:3] = upvector
-        self.matrix[2,0:3] = front
-        self.matrix[3,0:3] = eye
+        self.matrix[0, 0:3] = side
+        self.matrix[1, 0:3] = upvector
+        self.matrix[2, 0:3] = front
+        self.matrix[3, 0:3] = eye
 
         self.xmlnode = xmlnode
         """ElementTree representation of the transform."""
         if xmlnode is None:
             self.xmlnode = E.lookat(' '.join(map(str,
-                                        numpy.concatenate((self.eye, self.interest, self.upvector)) )))
+                                                 numpy.concatenate((self.eye, self.interest, self.upvector)))))
+
     @staticmethod
     def load(collada, node):
         floats = numpy.fromstring(node.text, dtype=numpy.float32, sep=' ')
@@ -377,8 +379,10 @@ class Node(SceneNode):
         :rtype: generator that yields the type specified
 
         """
-        if not matrix is None: M = numpy.dot( matrix, self.matrix )
-        else: M = self.matrix
+        if matrix is not None:
+            M = numpy.dot(matrix, self.matrix)
+        else:
+            M = self.matrix
         for node in self.children:
             for obj in node.objects(tipo, M):
                 yield obj
@@ -397,7 +401,7 @@ class Node(SceneNode):
             self.xmlnode.set('id', self.id)
         if self.name is not None:
             self.xmlnode.set('name', self.name)
-            
+
         for t in self.transforms:
             if t.xmlnode not in self.xmlnode:
                 self.xmlnode.append(t.xmlnode)
@@ -411,7 +415,7 @@ class Node(SceneNode):
                 self.xmlnode.remove(n)
 
     @staticmethod
-    def load( collada, node, localscope ):
+    def load(collada, node, localscope):
         id = node.get('id')
         name = node.get('name')
         children = []
@@ -451,7 +455,7 @@ class NodeNode(Node):
         self.node = node
         """An object of type :class:`collada.scene.Node` representing the node to bind in the scene"""
 
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the node node."""
         else:
@@ -466,7 +470,7 @@ class NodeNode(Node):
     matrix = property(lambda s: s.node.matrix)
 
     @staticmethod
-    def load( collada, node, localscope ):
+    def load(collada, node, localscope):
         url = node.get('url')
         if not url.startswith('#'):
             raise DaeMalformedError('Invalid url in node instance %s' % url)
@@ -474,7 +478,7 @@ class NodeNode(Node):
         if not referred_node:
             referred_node = collada.nodes.get(url[1:])
         if not referred_node:
-            raise DaeInstanceNotLoadedError('Node %s not found in library'%url)
+            raise DaeInstanceNotLoadedError('Node %s not found in library' % url)
         return NodeNode(referred_node, xmlnode=node)
 
     def save(self):
@@ -512,7 +516,7 @@ class GeometryNode(SceneNode):
           Each of these represents a material that the geometry is bound to."""
         if materials is not None:
             self.materials = materials
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the geometry node."""
         else:
@@ -527,23 +531,26 @@ class GeometryNode(SceneNode):
     def objects(self, tipo, matrix=None):
         """Yields a :class:`collada.geometry.BoundGeometry` if ``tipo=='geometry'``"""
         if tipo == 'geometry':
-            if matrix is None: matrix = numpy.identity(4, dtype=numpy.float32)
+            if matrix is None:
+                matrix = numpy.identity(4, dtype=numpy.float32)
             materialnodesbysymbol = {}
             for mat in self.materials:
                 materialnodesbysymbol[mat.symbol] = mat
             yield self.geometry.bind(matrix, materialnodesbysymbol)
 
     @staticmethod
-    def load( collada, node ):
+    def load(collada, node):
         url = node.get('url')
-        if not url.startswith('#'): raise DaeMalformedError('Invalid url in geometry instance %s' % url)
+        if not url.startswith('#'):
+            raise DaeMalformedError('Invalid url in geometry instance %s' % url)
         geometry = collada.geometries.get(url[1:])
-        if not geometry: raise DaeBrokenRefError('Geometry %s not found in library'%url)
-        matnodes = node.findall('%s/%s/%s'%( collada.tag('bind_material'), collada.tag('technique_common'), collada.tag('instance_material') ) )
+        if not geometry:
+            raise DaeBrokenRefError('Geometry %s not found in library' % url)
+        matnodes = node.findall('%s/%s/%s' % (collada.tag('bind_material'), collada.tag('technique_common'), collada.tag('instance_material')))
         materials = []
         for matnode in matnodes:
-            materials.append( MaterialNode.load(collada, matnode) )
-        return GeometryNode( geometry, materials, xmlnode=node)
+            materials.append(MaterialNode.load(collada, matnode))
+        return GeometryNode(geometry, materials, xmlnode=node)
 
     def save(self):
         """Saves the geometry node back to :attr:`xmlnode`"""
@@ -552,8 +559,8 @@ class GeometryNode(SceneNode):
         for m in self.materials:
             m.save()
 
-        matparent = self.xmlnode.find('%s/%s'%( tag('bind_material'), tag('technique_common') ) )
-        if matparent is None and len(self.materials)==0:
+        matparent = self.xmlnode.find('%s/%s' % (tag('bind_material'), tag('technique_common')))
+        if matparent is None and len(self.materials) == 0:
             return
         elif matparent is None:
             matparent = E.technique_common()
@@ -601,41 +608,45 @@ class ControllerNode(SceneNode):
         self.materials = materials
         """A list containing items of type :class:`collada.scene.MaterialNode`.
           Each of these represents a material that the controller is bound to."""
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the controller node."""
         else:
-            self.xmlnode = ElementTree.Element( collada.tag('instance_controller') )
-            bindnode = ElementTree.Element( collada.tag('bind_material') )
-            technode = ElementTree.Element( collada.tag('technique_common') )
-            bindnode.append( technode )
-            self.xmlnode.append( bindnode )
-            for mat in materials: technode.append( mat.xmlnode )
+            self.xmlnode = ElementTree.Element(collada.tag('instance_controller'))
+            bindnode = ElementTree.Element(collada.tag('bind_material'))
+            technode = ElementTree.Element(collada.tag('technique_common'))
+            bindnode.append(technode)
+            self.xmlnode.append(bindnode)
+            for mat in materials:
+                technode.append(mat.xmlnode)
 
     def objects(self, tipo, matrix=None):
         """Yields a :class:`collada.controller.BoundController` if ``tipo=='controller'``"""
         if tipo == 'controller':
-            if matrix is None: matrix = numpy.identity(4, dtype=numpy.float32)
+            if matrix is None:
+                matrix = numpy.identity(4, dtype=numpy.float32)
             materialnodesbysymbol = {}
             for mat in self.materials:
                 materialnodesbysymbol[mat.symbol] = mat
             yield self.controller.bind(matrix, materialnodesbysymbol)
 
     @staticmethod
-    def load( collada, node ):
+    def load(collada, node):
         url = node.get('url')
-        if not url.startswith('#'): raise DaeMalformedError('Invalid url in controller instance %s' % url)
+        if not url.startswith('#'):
+            raise DaeMalformedError('Invalid url in controller instance %s' % url)
         controller = collada.controllers.get(url[1:])
-        if not controller: raise DaeBrokenRefError('Controller %s not found in library'%url)
-        matnodes = node.findall('%s/%s/%s'%( collada.tag('bind_material'), collada.tag('technique_common'), collada.tag('instance_material') ) )
+        if not controller:
+            raise DaeBrokenRefError('Controller %s not found in library' % url)
+        matnodes = node.findall('%s/%s/%s' % (collada.tag('bind_material'), collada.tag('technique_common'), collada.tag('instance_material')))
         materials = []
         for matnode in matnodes:
-            materials.append( MaterialNode.load(collada, matnode) )
-        return ControllerNode( controller, materials, xmlnode=node)
+            materials.append(MaterialNode.load(collada, matnode))
+        return ControllerNode(controller, materials, xmlnode=node)
 
     def save(self):
         """Saves the controller node back to :attr:`xmlnode`"""
-        self.xmlnode.set('url', '#'+self.controller.id)
+        self.xmlnode.set('url', '#' + self.controller.id)
         for mat in self.materials:
             mat.save()
 
@@ -649,7 +660,7 @@ class ControllerNode(SceneNode):
 class MaterialNode(SceneNode):
     """Represents a material being instantiated in a scene, as defined in the collada <instance_material> tag."""
 
-    def __init__(self, symbol, target, inputs, xmlnode = None):
+    def __init__(self, symbol, target, inputs, xmlnode=None):
         """Creates a material node
 
         :param str symbol:
@@ -682,19 +693,20 @@ class MaterialNode(SceneNode):
         else:
             self.xmlnode = E.instance_material(
                 *[E.bind_vertex_input(semantic=sem, input_semantic=input_sem, input_set=set)
-                  for sem, input_sem, set in self.inputs]
-            , **{'symbol': self.symbol, 'target':"#%s"%self.target.id} )
+                  for sem, input_sem, set in self.inputs], **{'symbol': self.symbol, 'target': "#%s" % self.target.id})
 
     @staticmethod
     def load(collada, node):
         inputs = []
-        for inputnode in node.findall( collada.tag('bind_vertex_input') ):
-            inputs.append( ( inputnode.get('semantic'), inputnode.get('input_semantic'), inputnode.get('input_set') ) )
+        for inputnode in node.findall(collada.tag('bind_vertex_input')):
+            inputs.append((inputnode.get('semantic'), inputnode.get('input_semantic'), inputnode.get('input_set')))
         targetid = node.get('target')
-        if not targetid.startswith('#'): raise DaeMalformedError('Incorrect target id in material '+targetid)
+        if not targetid.startswith('#'):
+            raise DaeMalformedError('Incorrect target id in material ' + targetid)
         target = collada.materials.get(targetid[1:])
-        if not target: raise DaeBrokenRefError('Material %s not found'%targetid)
-        return MaterialNode(node.get('symbol'), target, inputs, xmlnode = node)
+        if not target:
+            raise DaeBrokenRefError('Material %s not found' % targetid)
+        return MaterialNode(node.get('symbol'), target, inputs, xmlnode=node)
 
     def objects(self):
         pass
@@ -702,11 +714,11 @@ class MaterialNode(SceneNode):
     def save(self):
         """Saves the material node back to :attr:`xmlnode`"""
         self.xmlnode.set('symbol', self.symbol)
-        self.xmlnode.set('target', "#%s"%self.target.id)
+        self.xmlnode.set('target', "#%s" % self.target.id)
 
         inputs_in = []
-        for i in self.xmlnode.findall( tag('bind_vertex_input') ):
-            input_tuple = ( i.get('semantic'), i.get('input_semantic'), i.get('input_set') )
+        for i in self.xmlnode.findall(tag('bind_vertex_input')):
+            input_tuple = (i.get('semantic'), i.get('input_semantic'), i.get('input_set'))
             if input_tuple not in self.inputs:
                 self.xmlnode.remove(i)
             else:
@@ -736,29 +748,32 @@ class CameraNode(SceneNode):
         """
         self.camera = camera
         """An object of type :class:`collada.camera.Camera` representing the instantiated camera"""
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the camera node."""
         else:
-            self.xmlnode = E.instance_camera(url="#%s"%camera.id)
+            self.xmlnode = E.instance_camera(url="#%s" % camera.id)
 
     def objects(self, tipo, matrix=None):
         """Yields a :class:`collada.camera.BoundCamera` if ``tipo=='camera'``"""
         if tipo == 'camera':
-            if matrix is None: matrix = numpy.identity(4, dtype=numpy.float32)
+            if matrix is None:
+                matrix = numpy.identity(4, dtype=numpy.float32)
             yield self.camera.bind(matrix)
 
     @staticmethod
-    def load( collada, node ):
+    def load(collada, node):
         url = node.get('url')
-        if not url.startswith('#'): raise DaeMalformedError('Invalid url in camera instance %s' % url)
+        if not url.startswith('#'):
+            raise DaeMalformedError('Invalid url in camera instance %s' % url)
         camera = collada.cameras.get(url[1:])
-        if not camera: raise DaeBrokenRefError('Camera %s not found in library'%url)
-        return CameraNode( camera, xmlnode=node)
+        if not camera:
+            raise DaeBrokenRefError('Camera %s not found in library' % url)
+        return CameraNode(camera, xmlnode=node)
 
     def save(self):
         """Saves the camera node back to :attr:`xmlnode`"""
-        self.xmlnode.set('url', '#'+self.camera.id)
+        self.xmlnode.set('url', '#' + self.camera.id)
 
     def __str__(self):
         return '<CameraNode camera=%s>' % (self.camera.id,)
@@ -781,32 +796,38 @@ class LightNode(SceneNode):
         """
         self.light = light
         """An object of type :class:`collada.light.Light` representing the instantiated light"""
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the light node."""
         else:
-            self.xmlnode = E.instance_light(url="#%s"%light.id)
+            self.xmlnode = E.instance_light(url="#%s" % light.id)
 
     def objects(self, tipo, matrix=None):
         """Yields a :class:`collada.light.BoundLight` if ``tipo=='light'``"""
         if tipo == 'light':
-            if matrix is None: matrix = numpy.identity(4, dtype=numpy.float32)
+            if matrix is None:
+                matrix = numpy.identity(4, dtype=numpy.float32)
             yield self.light.bind(matrix)
 
     @staticmethod
-    def load( collada, node ):
+    def load(collada, node):
         url = node.get('url')
-        if not url.startswith('#'): raise DaeMalformedError('Invalid url in light instance %s' % url)
+        if not url.startswith('#'):
+            raise DaeMalformedError('Invalid url in light instance %s' % url)
         light = collada.lights.get(url[1:])
-        if not light: raise DaeBrokenRefError('Light %s not found in library'%url)
-        return LightNode( light, xmlnode=node)
+        if not light:
+            raise DaeBrokenRefError('Light %s not found in library' % url)
+        return LightNode(light, xmlnode=node)
 
     def save(self):
         """Saves the light node back to :attr:`xmlnode`"""
-        self.xmlnode.set('url', '#'+self.light.id)
+        self.xmlnode.set('url', '#' + self.light.id)
 
-    def __str__(self): return '<LightNode light=%s>' % (self.light.id,)
-    def __repr__(self): return str(self)
+    def __str__(self):
+        return '<LightNode light=%s>' % (self.light.id,)
+
+    def __repr__(self):
+        return str(self)
 
 
 class ExtraNode(SceneNode):
@@ -819,7 +840,7 @@ class ExtraNode(SceneNode):
           Should be an ElementTree instance of tag type <extra>
 
         """
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the extra node."""
         else:
@@ -831,36 +852,48 @@ class ExtraNode(SceneNode):
                 yield e
 
     @staticmethod
-    def load( collada, node ):
+    def load(collada, node):
         return ExtraNode(node)
 
     def save(self):
         pass
 
 
-def loadNode( collada, node, localscope ):
+def loadNode(collada, node, localscope):
     """Generic scene node loading from an xml `node` and a `collada` object.
 
     Knowing the supported nodes, create the appropriate class for the given node
     and return it.
 
     """
-    if node.tag == collada.tag('node'): return Node.load(collada, node, localscope)
-    elif node.tag == collada.tag('translate'): return TranslateTransform.load(collada, node)
-    elif node.tag == collada.tag('rotate'): return RotateTransform.load(collada, node)
-    elif node.tag == collada.tag('scale'): return ScaleTransform.load(collada, node)
-    elif node.tag == collada.tag('matrix'): return MatrixTransform.load(collada, node)
-    elif node.tag == collada.tag('lookat'): return LookAtTransform.load(collada, node)
-    elif node.tag == collada.tag('instance_geometry'): return GeometryNode.load(collada, node)
-    elif node.tag == collada.tag('instance_camera'): return CameraNode.load(collada, node)
-    elif node.tag == collada.tag('instance_light'): return LightNode.load(collada, node)
-    elif node.tag == collada.tag('instance_controller'): return ControllerNode.load(collada, node)
-    elif node.tag == collada.tag('instance_node'): return NodeNode.load(collada, node, localscope)
+    if node.tag == collada.tag('node'):
+        return Node.load(collada, node, localscope)
+    elif node.tag == collada.tag('translate'):
+        return TranslateTransform.load(collada, node)
+    elif node.tag == collada.tag('rotate'):
+        return RotateTransform.load(collada, node)
+    elif node.tag == collada.tag('scale'):
+        return ScaleTransform.load(collada, node)
+    elif node.tag == collada.tag('matrix'):
+        return MatrixTransform.load(collada, node)
+    elif node.tag == collada.tag('lookat'):
+        return LookAtTransform.load(collada, node)
+    elif node.tag == collada.tag('instance_geometry'):
+        return GeometryNode.load(collada, node)
+    elif node.tag == collada.tag('instance_camera'):
+        return CameraNode.load(collada, node)
+    elif node.tag == collada.tag('instance_light'):
+        return LightNode.load(collada, node)
+    elif node.tag == collada.tag('instance_controller'):
+        return ControllerNode.load(collada, node)
+    elif node.tag == collada.tag('instance_node'):
+        return NodeNode.load(collada, node, localscope)
     elif node.tag == collada.tag('extra'):
         return ExtraNode.load(collada, node)
     elif node.tag == collada.tag('asset'):
         return None
-    else: raise DaeUnsupportedError('Unknown scene node %s' % str(node.tag))
+    else:
+        raise DaeUnsupportedError('Unknown scene node %s' % str(node.tag))
 
 
 class Scene(DaeObject):
@@ -885,13 +918,13 @@ class Scene(DaeObject):
         """A list of type :class:`collada.scene.Node` representing the nodes in the scene"""
         self.collada = collada
         """The collada instance this is part of"""
-        if xmlnode != None:
+        if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the scene node."""
         else:
             self.xmlnode = E.visual_scene(id=self.id)
             for node in nodes:
-                self.xmlnode.append( node.xmlnode )
+                self.xmlnode.append(node.xmlnode)
 
     def objects(self, tipo):
         """Iterate through all objects in the scene that match `tipo`.
@@ -906,10 +939,11 @@ class Scene(DaeObject):
         """
         matrix = None
         for node in self.nodes:
-            for obj in node.objects(tipo, matrix): yield obj
+            for obj in node.objects(tipo, matrix):
+                yield obj
 
     @staticmethod
-    def load( collada, node ):
+    def load(collada, node):
         id = node.get('id')
         nodes = []
         tried_loading = []
@@ -924,7 +958,7 @@ class Scene(DaeObject):
                 collada.handleError(ex)
             else:
                 if N is not None:
-                    nodes.append( N )
+                    nodes.append(N)
                     if N.id and N.id not in localscope:
                         localscope[N.id] = N
                     succeeded = True
@@ -940,7 +974,7 @@ class Scene(DaeObject):
                     collada.handleError(ex)
                 else:
                     if N is not None:
-                        nodes.append( N )
+                        nodes.append(N)
                         succeeded = True
             tried_loading = next_tried
         if len(tried_loading) > 0:
@@ -966,4 +1000,3 @@ class Scene(DaeObject):
 
     def __repr__(self):
         return str(self)
-

--- a/collada/scene.py
+++ b/collada/scene.py
@@ -55,7 +55,7 @@ class SceneNode(DaeObject):
         :param str tipo:
           A string for the desired object type. This can be one of 'geometry',
           'camera', 'light', or 'controller'.
-        :param numpy.matrix matrix:
+        :param numpy.array matrix:
           An optional transformation matrix
 
         :rtype: generator that yields the type specified
@@ -373,7 +373,7 @@ class Node(SceneNode):
         :param str tipo:
           A string for the desired object type. This can be one of 'geometry',
           'camera', 'light', or 'controller'.
-        :param numpy.matrix matrix:
+        :param numpy.array matrix:
           An optional transformation matrix
 
         :rtype: generator that yields the type specified

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -1,4 +1,4 @@
-#encoding:UTF-8
+# encoding:UTF-8
 ####################################################################
 #                                                                  #
 # THIS FILE IS PART OF THE pycollada LIBRARY SOURCE CODE.          #
@@ -30,11 +30,13 @@ XML_XSD = str(resource_string(
     'collada',
     'resources/xsd.xml').decode('utf-8'))
 
+
 class ColladaResolver(lxml.etree.Resolver):
     """COLLADA XML Resolver. If a known URL referenced
     from the COLLADA spec is resolved, a cached local
     copy is returned instead of initiating a network
     request"""
+
     def resolve(self, url, id, context):
         """Currently Resolves:
          * http://www.w3.org/2001/03/xml.xsd
@@ -58,10 +60,10 @@ class ColladaValidator(object):
             self._parser = lxml.etree.XMLParser()
             self._parser.resolvers.add(ColladaResolver())
             self.COLLADA_SCHEMA_1_4_1_DOC = lxml.etree.parse(
-                    BytesIO(bytes(COLLADA_SCHEMA_1_4_1, encoding='utf-8')),
-                    self._parser)
+                BytesIO(bytes(COLLADA_SCHEMA_1_4_1, encoding='utf-8')),
+                self._parser)
             self._COLLADA_SCHEMA_1_4_1_INSTANCE = lxml.etree.XMLSchema(
-                    self.COLLADA_SCHEMA_1_4_1_DOC)
+                self.COLLADA_SCHEMA_1_4_1_DOC)
         return self._COLLADA_SCHEMA_1_4_1_INSTANCE
 
     COLLADA_SCHEMA_1_4_1_INSTANCE = property(_getColladaSchemaInstance)
@@ -70,4 +72,3 @@ class ColladaValidator(object):
     def validate(self, *args, **kwargs):
         """A wrapper for lxml.XMLSchema.validate"""
         return self.COLLADA_SCHEMA_1_4_1_INSTANCE.validate(*args, **kwargs)
-

--- a/collada/tests/test_asset.py
+++ b/collada/tests/test_asset.py
@@ -99,5 +99,6 @@ class TestAsset(unittest.TestCase):
         self.assertEqual(asset.modified, time2)
         self.assertEqual(len(asset.contributors), 2)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/collada/tests/test_camera.py
+++ b/collada/tests/test_camera.py
@@ -13,7 +13,7 @@ class TestCamera(unittest.TestCase):
         self.dummy = collada.Collada(validate_output=True)
 
     def test_perspective_camera_xfov_yfov_aspect_ratio(self):
-        #test invalid xfov,yfov,aspect_ratio combinations
+        # test invalid xfov,yfov,aspect_ratio combinations
         with self.assertRaises(DaeMalformedError):
             cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=None, yfov=None, aspect_ratio=None)
         with self.assertRaises(DaeMalformedError):
@@ -21,31 +21,31 @@ class TestCamera(unittest.TestCase):
         with self.assertRaises(DaeMalformedError):
             cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=None, yfov=None, aspect_ratio=50)
 
-        #xfov alone
+        # xfov alone
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=30, yfov=None, aspect_ratio=None)
         self.assertEqual(cam.xfov, 30)
         self.assertIsNone(cam.yfov)
         self.assertIsNone(cam.aspect_ratio)
 
-        #yfov alone
+        # yfov alone
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=None, yfov=50, aspect_ratio=None)
         self.assertIsNone(cam.xfov)
         self.assertEqual(cam.yfov, 50)
         self.assertIsNone(cam.aspect_ratio)
 
-        #xfov + yfov
+        # xfov + yfov
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=30, yfov=50, aspect_ratio=None)
         self.assertEqual(cam.xfov, 30)
         self.assertEqual(cam.yfov, 50)
         self.assertIsNone(cam.aspect_ratio)
 
-        #xfov + aspect_ratio
+        # xfov + aspect_ratio
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=30, yfov=None, aspect_ratio=1)
         self.assertEqual(cam.xfov, 30)
         self.assertIsNone(cam.yfov)
         self.assertEqual(cam.aspect_ratio, 1)
 
-        #yfov + aspect_ratio
+        # yfov + aspect_ratio
         cam = collada.camera.PerspectiveCamera("mycam", 1, 1000, xfov=None, yfov=50, aspect_ratio=1)
         self.assertIsNone(cam.xfov)
         self.assertEqual(cam.yfov, 50)
@@ -97,7 +97,7 @@ class TestCamera(unittest.TestCase):
             cam.save()
 
     def test_orthographic_camera_xmag_ymag_aspect_ratio(self):
-        #test invalid xmag,ymag,aspect_ratio combinations
+        # test invalid xmag,ymag,aspect_ratio combinations
         with self.assertRaises(DaeMalformedError):
             cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=None, ymag=None, aspect_ratio=None)
         with self.assertRaises(DaeMalformedError):
@@ -105,31 +105,31 @@ class TestCamera(unittest.TestCase):
         with self.assertRaises(DaeMalformedError):
             cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=None, ymag=None, aspect_ratio=50)
 
-        #xmag alone
+        # xmag alone
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=30, ymag=None, aspect_ratio=None)
         self.assertEqual(cam.xmag, 30)
         self.assertIsNone(cam.ymag)
         self.assertIsNone(cam.aspect_ratio)
 
-        #ymag alone
+        # ymag alone
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=None, ymag=50, aspect_ratio=None)
         self.assertIsNone(cam.xmag)
         self.assertEqual(cam.ymag, 50)
         self.assertIsNone(cam.aspect_ratio)
 
-        #xmag + ymag
+        # xmag + ymag
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=30, ymag=50, aspect_ratio=None)
         self.assertEqual(cam.xmag, 30)
         self.assertEqual(cam.ymag, 50)
         self.assertIsNone(cam.aspect_ratio)
 
-        #xmag + aspect_ratio
+        # xmag + aspect_ratio
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=30, ymag=None, aspect_ratio=1)
         self.assertEqual(cam.xmag, 30)
         self.assertIsNone(cam.ymag)
         self.assertEqual(cam.aspect_ratio, 1)
 
-        #ymag + aspect_ratio
+        # ymag + aspect_ratio
         cam = collada.camera.OrthographicCamera("mycam", 1, 1000, xmag=None, ymag=50, aspect_ratio=1)
         self.assertIsNone(cam.xmag)
         self.assertEqual(cam.ymag, 50)
@@ -179,6 +179,7 @@ class TestCamera(unittest.TestCase):
         cam.xmag = 20
         with self.assertRaises(DaeMalformedError):
             cam.save()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/collada/tests/test_collada.py
+++ b/collada/tests/test_collada.py
@@ -14,7 +14,7 @@ class TestCollada(unittest.TestCase):
 
     def setUp(self):
         self.dummy = collada.Collada(validate_output=True)
-        self.datadir = os.path.join(os.path.dirname(os.path.realpath( __file__ )), "data")
+        self.datadir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 
     def test_collada_duck_tris(self):
         f = os.path.join(self.datadir, "duck_triangles.dae")
@@ -22,7 +22,8 @@ class TestCollada(unittest.TestCase):
 
         self.assertEqual(mesh.assetInfo.contributors[0].author, 'gcorson')
         self.assertEqual(mesh.assetInfo.contributors[0].authoring_tool, 'Maya 8.0 | ColladaMaya v3.02 | FCollada v3.2')
-        self.assertEqual(mesh.assetInfo.contributors[0].source_data, 'file:///C:/vs2005/sample_data/Complete_Packages/SCEA_Private/Maya_MoonLander/Moonlander/untitled')
+        self.assertEqual(mesh.assetInfo.contributors[0].source_data,
+                         'file:///C:/vs2005/sample_data/Complete_Packages/SCEA_Private/Maya_MoonLander/Moonlander/untitled')
         self.assertEqual(len(mesh.assetInfo.contributors[0].copyright), 595)
         self.assertEqual(len(mesh.assetInfo.contributors[0].comments), 449)
 
@@ -62,7 +63,8 @@ class TestCollada(unittest.TestCase):
 
         self.assertEqual(mesh.assetInfo.contributors[0].author, 'gcorson')
         self.assertEqual(mesh.assetInfo.contributors[0].authoring_tool, 'Maya 8.0 | ColladaMaya v3.02 | FCollada v3.2')
-        self.assertEqual(mesh.assetInfo.contributors[0].source_data, 'file:///C:/vs2005/sample_data/Complete_Packages/SCEA_Private/Maya_MoonLander/Moonlander/untitled')
+        self.assertEqual(mesh.assetInfo.contributors[0].source_data,
+                         'file:///C:/vs2005/sample_data/Complete_Packages/SCEA_Private/Maya_MoonLander/Moonlander/untitled')
         self.assertEqual(len(mesh.assetInfo.contributors[0].copyright), 595)
         self.assertEqual(len(mesh.assetInfo.contributors[0].comments), 449)
 
@@ -147,22 +149,22 @@ class TestCollada(unittest.TestCase):
         self.assertEqual(mesh.scene, None)
         self.assertIsNotNone(str(mesh))
 
-        floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1,0.2,0.3]), ('X', 'Y', 'Z'))
-        geometry1 = collada.geometry.Geometry(mesh, "geometry1", "mygeometry1", {"myfloatsource":floatsource})
+        floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1, 0.2, 0.3]), ('X', 'Y', 'Z'))
+        geometry1 = collada.geometry.Geometry(mesh, "geometry1", "mygeometry1", {"myfloatsource": floatsource})
         mesh.geometries.append(geometry1)
 
-        linefloats = [1,1,-1, 1,-1,-1, -1,-0.9999998,-1, -0.9999997,1,-1, 1,0.9999995,1, 0.9999994,-1.000001,1]
+        linefloats = [1, 1, -1, 1, -1, -1, -1, -0.9999998, -1, -0.9999997, 1, -1, 1, 0.9999995, 1, 0.9999994, -1.000001, 1]
         linefloatsrc = collada.source.FloatSource("mylinevertsource", numpy.array(linefloats), ('X', 'Y', 'Z'))
         geometry2 = collada.geometry.Geometry(mesh, "geometry2", "mygeometry2", [linefloatsrc])
         input_list = collada.source.InputList()
         input_list.addInput(0, 'VERTEX', "#mylinevertsource")
-        indices = numpy.array([0,1, 1,2, 2,3, 3,4, 4,5])
+        indices = numpy.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5])
         lineset1 = geometry2.createLineSet(indices, input_list, "mymaterial2")
         geometry2.primitives.append(lineset1)
         mesh.geometries.append(geometry2)
 
-        ambientlight = collada.light.AmbientLight("myambientlight", (1,1,1))
-        pointlight = collada.light.PointLight("mypointlight", (1,1,1))
+        ambientlight = collada.light.AmbientLight("myambientlight", (1, 1, 1))
+        pointlight = collada.light.PointLight("mypointlight", (1, 1, 1))
         mesh.lights.append(ambientlight)
         mesh.lights.append(pointlight)
 
@@ -242,7 +244,7 @@ class TestCollada(unittest.TestCase):
         loaded_mesh.geometries.pop(0)
         loaded_mesh.geometries.append(geometry3)
 
-        dirlight = collada.light.DirectionalLight("mydirlight", (1,1,1))
+        dirlight = collada.light.DirectionalLight("mydirlight", (1, 1, 1))
         loaded_mesh.lights.pop(0)
         loaded_mesh.lights.append(dirlight)
 
@@ -378,6 +380,7 @@ class TestCollada(unittest.TestCase):
             self.assertEqual(len(mesh.geometries), 8)
             # scene should have one root node
             self.assertEqual(len(mesh.scene.nodes), 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/collada/tests/test_geometry.py
+++ b/collada/tests/test_geometry.py
@@ -14,18 +14,18 @@ class TestGeometry(unittest.TestCase):
         self.dummy = collada.Collada(validate_output=True)
 
     def test_empty_geometry_saving(self):
-        floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1,0.2,0.3]), ('X', 'Y', 'Z'))
-        geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mygeometry", {"myfloatsource":floatsource})
+        floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1, 0.2, 0.3]), ('X', 'Y', 'Z'))
+        geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mygeometry", {"myfloatsource": floatsource})
         self.assertEqual(geometry.id, "geometry0")
         self.assertEqual(geometry.name, "mygeometry")
         self.assertEqual(len(geometry.primitives), 0)
-        self.assertDictEqual(geometry.sourceById, {"myfloatsource":floatsource})
+        self.assertDictEqual(geometry.sourceById, {"myfloatsource": floatsource})
         self.assertIsNotNone(str(geometry))
 
         geometry.id = "geometry1"
         geometry.name = "yourgeometry"
-        othersource1 = collada.source.FloatSource("yourfloatsource", numpy.array([0.4,0.5,0.6]), ('X', 'Y', 'Z'))
-        othersource2 = collada.source.FloatSource("hisfloatsource", numpy.array([0.7,0.8,0.9]), ('X', 'Y', 'Z'))
+        othersource1 = collada.source.FloatSource("yourfloatsource", numpy.array([0.4, 0.5, 0.6]), ('X', 'Y', 'Z'))
+        othersource2 = collada.source.FloatSource("hisfloatsource", numpy.array([0.7, 0.8, 0.9]), ('X', 'Y', 'Z'))
         geometry.sourceById[othersource1.id] = othersource1
         geometry.sourceById[othersource2.id] = othersource2
         del geometry.sourceById[floatsource.id]
@@ -40,12 +40,12 @@ class TestGeometry(unittest.TestCase):
         self.assertNotIn(floatsource.id, loaded_geometry.sourceById)
 
     def test_geometry_lineset_adding_with_material(self):
-        linefloats = [1,1,-1, 1,-1,-1, -1,-0.9999998,-1, -0.9999997,1,-1, 1,0.9999995,1, 0.9999994,-1.000001,1]
+        linefloats = [1, 1, -1, 1, -1, -1, -1, -0.9999998, -1, -0.9999997, 1, -1, 1, 0.9999995, 1, 0.9999994, -1.000001, 1]
         linefloatsrc = collada.source.FloatSource("mylinevertsource", numpy.array(linefloats), ('X', 'Y', 'Z'))
         geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mygeometry", [linefloatsrc])
         input_list = collada.source.InputList()
         input_list.addInput(0, 'VERTEX', "#mylinevertsource")
-        indices = numpy.array([0,1, 1,2, 2,3, 3,4, 4,5])
+        indices = numpy.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5])
         lineset1 = geometry.createLineSet(indices, input_list, "mymaterial")
         lineset2 = geometry.createLineSet(indices, input_list, "mymaterial")
         geometry.primitives.append(lineset1)
@@ -73,12 +73,12 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(loaded_geometry2.primitives[1].material, lineset3.material)
 
     def test_geometry_lineset_adding_without_material(self):
-        linefloats = [1,1,-1, 1,-1,-1, -1,-0.9999998,-1, -0.9999997,1,-1, 1,0.9999995,1, 0.9999994,-1.000001,1]
+        linefloats = [1, 1, -1, 1, -1, -1, -1, -0.9999998, -1, -0.9999997, 1, -1, 1, 0.9999995, 1, 0.9999994, -1.000001, 1]
         linefloatsrc = collada.source.FloatSource("mylinevertsource", numpy.array(linefloats), ('X', 'Y', 'Z'))
         geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mygeometry", [linefloatsrc])
         input_list = collada.source.InputList()
         input_list.addInput(0, 'VERTEX', "#mylinevertsource")
-        indices = numpy.array([0,1, 1,2, 2,3, 3,4, 4,5])
+        indices = numpy.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5])
         lineset1 = geometry.createLineSet(indices, input_list)
         lineset2 = geometry.createLineSet(indices, input_list)
         geometry.primitives.append(lineset1)
@@ -104,9 +104,9 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(len(loaded_geometry2.primitives), 2)
 
     def test_geometry_triangleset_adding(self):
-        vert_floats = [-50,50,50,50,50,50,-50,-50,50,50,-50,50,-50,50,-50,50,50,-50,-50,-50,-50,50,-50,-50]
-        normal_floats = [0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,
-                         -1,0,0,-1,0,0,-1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1]
+        vert_floats = [-50, 50, 50, 50, 50, 50, -50, -50, 50, 50, -50, 50, -50, 50, -50, 50, 50, -50, -50, -50, -50, 50, -50, -50]
+        normal_floats = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, -1, 0, 0,
+                         -1, 0, 0, -1, 0, 0, -1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1]
         vert_src = collada.source.FloatSource("cubeverts-array", numpy.array(vert_floats), ('X', 'Y', 'Z'))
         normal_src = collada.source.FloatSource("cubenormals-array", numpy.array(normal_floats), ('X', 'Y', 'Z'))
         self.assertEqual(len(vert_src), 8)
@@ -118,8 +118,8 @@ class TestGeometry(unittest.TestCase):
         input_list.addInput(0, 'VERTEX', "#cubeverts-array")
         input_list.addInput(1, 'NORMAL', "#cubenormals-array")
 
-        indices = numpy.array([0,0,2,1,3,2,0,0,3,2,1,3,0,4,1,5,5,6,0,4,5,6,4,7,6,8,7,9,3,10,6,8,3,10,2,11,0,12,
-                        4,13,6,14,0,12,6,14,2,15,3,16,7,17,5,18,3,16,5,18,1,19,5,20,7,21,6,22,5,20,6,22,4,23])
+        indices = numpy.array([0, 0, 2, 1, 3, 2, 0, 0, 3, 2, 1, 3, 0, 4, 1, 5, 5, 6, 0, 4, 5, 6, 4, 7, 6, 8, 7, 9, 3, 10, 6, 8, 3, 10, 2, 11, 0, 12,
+                               4, 13, 6, 14, 0, 12, 6, 14, 2, 15, 3, 16, 7, 17, 5, 18, 3, 16, 5, 18, 1, 19, 5, 20, 7, 21, 6, 22, 5, 20, 6, 22, 4, 23])
         triangleset = geometry.createTriangleSet(indices, input_list)
         self.assertIsNotNone(str(triangleset))
 
@@ -134,9 +134,9 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(len(loaded_geometry.primitives[0]), 12)
 
     def test_geometry_polylist_adding(self):
-        vert_floats = [-50,50,50,50,50,50,-50,-50,50,50,-50,50,-50,50,-50,50,50,-50,-50,-50,-50,50,-50,-50]
-        normal_floats = [0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,
-                         -1,0,0,-1,0,0,-1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1]
+        vert_floats = [-50, 50, 50, 50, 50, 50, -50, -50, 50, 50, -50, 50, -50, 50, -50, 50, 50, -50, -50, -50, -50, 50, -50, -50]
+        normal_floats = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, -1, 0, 0,
+                         -1, 0, 0, -1, 0, 0, -1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1]
         vert_src = collada.source.FloatSource("cubeverts-array", numpy.array(vert_floats), ('X', 'Y', 'Z'))
         normal_src = collada.source.FloatSource("cubenormals-array", numpy.array(normal_floats), ('X', 'Y', 'Z'))
 
@@ -146,9 +146,9 @@ class TestGeometry(unittest.TestCase):
         input_list.addInput(0, 'VERTEX', "#cubeverts-array")
         input_list.addInput(1, 'NORMAL', "#cubenormals-array")
 
-        vcounts = numpy.array([4,4,4,4,4,4])
-        indices = numpy.array([0,0,2,1,3,2,1,3,0,4,1,5,5,6,4,7,6,8,7,9,3,10,2,11,0,12,4,13,6,14,2,
-                               15,3,16,7,17,5,18,1,19,5,20,7,21,6,22,4,23])
+        vcounts = numpy.array([4, 4, 4, 4, 4, 4])
+        indices = numpy.array([0, 0, 2, 1, 3, 2, 1, 3, 0, 4, 1, 5, 5, 6, 4, 7, 6, 8, 7, 9, 3, 10, 2, 11, 0, 12, 4, 13, 6, 14, 2,
+                               15, 3, 16, 7, 17, 5, 18, 1, 19, 5, 20, 7, 21, 6, 22, 4, 23])
         polylist = geometry.createPolylist(indices, vcounts, input_list)
         self.assertIsNotNone(str(polylist))
 
@@ -164,9 +164,9 @@ class TestGeometry(unittest.TestCase):
         self.assertEqual(len(loaded_geometry.primitives[0]), 6)
 
     def test_geometry_polygons_adding(self):
-        vert_floats = [-50,50,50,50,50,50,-50,-50,50,50,-50,50,-50,50,-50,50,50,-50,-50,-50,-50,50,-50,-50]
-        normal_floats = [0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,
-                         -1,0,0,-1,0,0,-1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1]
+        vert_floats = [-50, 50, 50, 50, 50, 50, -50, -50, 50, 50, -50, 50, -50, 50, -50, 50, 50, -50, -50, -50, -50, 50, -50, -50]
+        normal_floats = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, -1, 0, 0,
+                         -1, 0, 0, -1, 0, 0, -1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1]
         vert_src = collada.source.FloatSource("cubeverts-array", numpy.array(vert_floats), ('X', 'Y', 'Z'))
         normal_src = collada.source.FloatSource("cubenormals-array", numpy.array(normal_floats), ('X', 'Y', 'Z'))
 
@@ -177,12 +177,12 @@ class TestGeometry(unittest.TestCase):
         input_list.addInput(1, 'NORMAL', "#cubenormals-array")
 
         indices = []
-        indices.append(numpy.array([0,0,2,1,3,2,1,3], dtype=numpy.int32))
-        indices.append(numpy.array([0,4,1,5,5,6,4,7], dtype=numpy.int32))
-        indices.append(numpy.array([6,8,7,9,3,10,2,11], dtype=numpy.int32))
-        indices.append(numpy.array([0,12,4,13,6,14,2,15], dtype=numpy.int32))
-        indices.append(numpy.array([3,16,7,17,5,18,1,19], dtype=numpy.int32))
-        indices.append(numpy.array([5,20,7,21,6,22,4,23], dtype=numpy.int32))
+        indices.append(numpy.array([0, 0, 2, 1, 3, 2, 1, 3], dtype=numpy.int32))
+        indices.append(numpy.array([0, 4, 1, 5, 5, 6, 4, 7], dtype=numpy.int32))
+        indices.append(numpy.array([6, 8, 7, 9, 3, 10, 2, 11], dtype=numpy.int32))
+        indices.append(numpy.array([0, 12, 4, 13, 6, 14, 2, 15], dtype=numpy.int32))
+        indices.append(numpy.array([3, 16, 7, 17, 5, 18, 1, 19], dtype=numpy.int32))
+        indices.append(numpy.array([5, 20, 7, 21, 6, 22, 4, 23], dtype=numpy.int32))
 
         polygons = geometry.createPolygons(indices, input_list)
         self.assertIsNotNone(str(polygons))
@@ -197,6 +197,7 @@ class TestGeometry(unittest.TestCase):
 
         self.assertEqual(len(loaded_geometry.primitives), 1)
         self.assertEqual(len(loaded_geometry.primitives[0]), 6)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/collada/tests/test_ignore.py
+++ b/collada/tests/test_ignore.py
@@ -1,5 +1,4 @@
 import os
-import numpy
 import unittest
 
 import collada
@@ -25,7 +24,7 @@ class TestColladaIgnore(unittest.TestCase):
         f = os.path.join(self.datadir, "cube_tristrips.dae")
         raised = False
         try:
-            mesh = collada.Collada(f)
+            collada.Collada(f)
         except DaeIncompleteError:
             # this should have raised
             raised = True
@@ -34,7 +33,7 @@ class TestColladaIgnore(unittest.TestCase):
 
         raised = False
         try:
-            mesh = collada.Collada(
+            collada.Collada(
                 f, ignore=[DaeMalformedError])
         except DaeIncompleteError:
             raised = True
@@ -62,7 +61,7 @@ class TestColladaIgnore(unittest.TestCase):
         f = os.path.join(self.datadir, "earthCylindrical.DAE")
         raised = False
         try:
-            mesh = collada.Collada(f)
+            collada.Collada(f)
         except DaeMalformedError:
             # this should have raised
             raised = True
@@ -71,7 +70,7 @@ class TestColladaIgnore(unittest.TestCase):
 
         raised = False
         try:
-            mesh = collada.Collada(f, ignore=[DaeMalformedError])
+            collada.Collada(f, ignore=[DaeMalformedError])
         except DaeError:
             # this should have raised
             raised = True
@@ -79,10 +78,10 @@ class TestColladaIgnore(unittest.TestCase):
             raise ValueError('should have raised an error!')
 
         # should't have crashed
-        m = collada.Collada(f, ignore=[DaeMalformedError,
-                                       DaeBrokenRefError])
+        collada.Collada(f, ignore=[DaeMalformedError,
+                                   DaeBrokenRefError])
         # should have also loaded using the parent class
-        m = collada.Collada(f, ignore=[DaeError])
+        collada.Collada(f, ignore=[DaeError])
 
 
 if __name__ == '__main__':

--- a/collada/tests/test_iteration.py
+++ b/collada/tests/test_iteration.py
@@ -1,10 +1,9 @@
+from collada.util import unittest
+import collada
 import numpy
 from collada.xmlutil import etree
 fromstring = etree.fromstring
 tostring = etree.tostring
-
-import collada
-from collada.util import unittest
 
 
 class TestIteration(unittest.TestCase):
@@ -15,9 +14,9 @@ class TestIteration(unittest.TestCase):
     def test_triangle_iterator_vert_normals(self):
         mesh = collada.Collada(validate_output=True)
 
-        vert_floats = [-50,50,50,50,50,50,-50,-50,50,50,-50,50,-50,50,-50,50,50,-50,-50,-50,-50,50,-50,-50]
-        normal_floats = [0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,
-                         -1,0,0,-1,0,0,-1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1]
+        vert_floats = [-50, 50, 50, 50, 50, 50, -50, -50, 50, 50, -50, 50, -50, 50, -50, 50, 50, -50, -50, -50, -50, 50, -50, -50]
+        normal_floats = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, -1, 0, 0,
+                         -1, 0, 0, -1, 0, 0, -1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1]
         vert_src = collada.source.FloatSource("cubeverts-array", numpy.array(vert_floats), ('X', 'Y', 'Z'))
         normal_src = collada.source.FloatSource("cubenormals-array", numpy.array(normal_floats), ('X', 'Y', 'Z'))
         geometry = collada.geometry.Geometry(mesh, "geometry0", "mycube", [vert_src, normal_src], [])
@@ -26,8 +25,8 @@ class TestIteration(unittest.TestCase):
         input_list.addInput(0, 'VERTEX', "#cubeverts-array")
         input_list.addInput(1, 'NORMAL', "#cubenormals-array")
 
-        indices = numpy.array([0,0,2,1,3,2,0,0,3,2,1,3,0,4,1,5,5,6,0,4,5,6,4,7,6,8,7,9,3,10,6,8,3,10,2,11,0,12,
-                        4,13,6,14,0,12,6,14,2,15,3,16,7,17,5,18,3,16,5,18,1,19,5,20,7,21,6,22,5,20,6,22,4,23])
+        indices = numpy.array([0, 0, 2, 1, 3, 2, 0, 0, 3, 2, 1, 3, 0, 4, 1, 5, 5, 6, 0, 4, 5, 6, 4, 7, 6, 8, 7, 9, 3, 10, 6, 8, 3, 10, 2, 11, 0, 12,
+                               4, 13, 6, 14, 0, 12, 6, 14, 2, 15, 3, 16, 7, 17, 5, 18, 3, 16, 5, 18, 1, 19, 5, 20, 7, 21, 6, 22, 5, 20, 6, 22, 4, 23])
         triangleset = geometry.createTriangleSet(indices, input_list, "cubematerial")
         geometry.primitives.append(triangleset)
         mesh.geometries.append(geometry)
@@ -49,9 +48,9 @@ class TestIteration(unittest.TestCase):
         tris = list(prims[0])
         self.assertEqual(len(tris), 12)
 
-        self.assertEqual(list(tris[0].vertices[0]), [-50.0,  50.0,  50.0])
-        self.assertEqual(list(tris[0].vertices[1]), [-50.0,  -50.0,  50.0])
-        self.assertEqual(list(tris[0].vertices[2]), [50.0,  -50.0,  50.0])
+        self.assertEqual(list(tris[0].vertices[0]), [-50.0, 50.0, 50.0])
+        self.assertEqual(list(tris[0].vertices[1]), [-50.0, -50.0, 50.0])
+        self.assertEqual(list(tris[0].vertices[2]), [50.0, -50.0, 50.0])
         self.assertEqual(list(tris[0].normals[0]), [0.0, 0.0, 1.0])
         self.assertEqual(list(tris[0].normals[1]), [0.0, 0.0, 1.0])
         self.assertEqual(list(tris[0].normals[2]), [0.0, 0.0, 1.0])
@@ -64,10 +63,9 @@ class TestIteration(unittest.TestCase):
     def test_polylist_iterator_vert_normals(self):
         mesh = collada.Collada(validate_output=True)
 
-
-        vert_floats = [-50,50,50,50,50,50,-50,-50,50,50,-50,50,-50,50,-50,50,50,-50,-50,-50,-50,50,-50,-50]
-        normal_floats = [0,0,1,0,0,1,0,0,1,0,0,1,0,1,0,0,1,0,0,1,0,0,1,0,0,-1,0,0,-1,0,0,-1,0,0,-1,0,-1,0,0,
-                         -1,0,0,-1,0,0,-1,0,0,1,0,0,1,0,0,1,0,0,1,0,0,0,0,-1,0,0,-1,0,0,-1,0,0,-1]
+        vert_floats = [-50, 50, 50, 50, 50, 50, -50, -50, 50, 50, -50, 50, -50, 50, -50, 50, 50, -50, -50, -50, -50, 50, -50, -50]
+        normal_floats = [0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, -1, 0, 0,
+                         -1, 0, 0, -1, 0, 0, -1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1]
         vert_src = collada.source.FloatSource("cubeverts-array", numpy.array(vert_floats), ('X', 'Y', 'Z'))
         normal_src = collada.source.FloatSource("cubenormals-array", numpy.array(normal_floats), ('X', 'Y', 'Z'))
 
@@ -77,9 +75,9 @@ class TestIteration(unittest.TestCase):
         input_list.addInput(0, 'VERTEX', "#cubeverts-array")
         input_list.addInput(1, 'NORMAL', "#cubenormals-array")
 
-        vcounts = numpy.array([4,4,4,4,4,4])
-        indices = numpy.array([0,0,2,1,3,2,1,3,0,4,1,5,5,6,4,7,6,8,7,9,3,10,2,11,0,12,4,13,6,14,2,
-                               15,3,16,7,17,5,18,1,19,5,20,7,21,6,22,4,23])
+        vcounts = numpy.array([4, 4, 4, 4, 4, 4])
+        indices = numpy.array([0, 0, 2, 1, 3, 2, 1, 3, 0, 4, 1, 5, 5, 6, 4, 7, 6, 8, 7, 9, 3, 10, 2, 11, 0, 12, 4, 13, 6, 14, 2,
+                               15, 3, 16, 7, 17, 5, 18, 1, 19, 5, 20, 7, 21, 6, 22, 4, 23])
         polylist = geometry.createPolylist(indices, vcounts, input_list, "cubematerial")
 
         geometry.primitives.append(polylist)
@@ -102,9 +100,9 @@ class TestIteration(unittest.TestCase):
         poly = list(prims[0])
         self.assertEqual(len(poly), 6)
 
-        self.assertEqual(list(poly[0].vertices[0]), [-50.0,  50.0,  50.0])
-        self.assertEqual(list(poly[0].vertices[1]), [-50.0,  -50.0,  50.0])
-        self.assertEqual(list(poly[0].vertices[2]), [50.0,  -50.0,  50.0])
+        self.assertEqual(list(poly[0].vertices[0]), [-50.0, 50.0, 50.0])
+        self.assertEqual(list(poly[0].vertices[1]), [-50.0, -50.0, 50.0])
+        self.assertEqual(list(poly[0].vertices[2]), [50.0, -50.0, 50.0])
         self.assertEqual(list(poly[0].normals[0]), [0.0, 0.0, 1.0])
         self.assertEqual(list(poly[0].normals[1]), [0.0, 0.0, 1.0])
         self.assertEqual(list(poly[0].normals[2]), [0.0, 0.0, 1.0])
@@ -116,9 +114,9 @@ class TestIteration(unittest.TestCase):
 
         tris = list(poly[0].triangles())
 
-        self.assertEqual(list(tris[0].vertices[0]), [-50.0,  50.0,  50.0])
-        self.assertEqual(list(tris[0].vertices[1]), [-50.0,  -50.0,  50.0])
-        self.assertEqual(list(tris[0].vertices[2]), [50.0,  -50.0,  50.0])
+        self.assertEqual(list(tris[0].vertices[0]), [-50.0, 50.0, 50.0])
+        self.assertEqual(list(tris[0].vertices[1]), [-50.0, -50.0, 50.0])
+        self.assertEqual(list(tris[0].vertices[2]), [50.0, -50.0, 50.0])
         self.assertEqual(list(tris[0].normals[0]), [0.0, 0.0, 1.0])
         self.assertEqual(list(tris[0].normals[1]), [0.0, 0.0, 1.0])
         self.assertEqual(list(tris[0].normals[2]), [0.0, 0.0, 1.0])
@@ -128,6 +126,6 @@ class TestIteration(unittest.TestCase):
         self.assertEqual(list(tris[0].normal_indices), [0, 1, 2])
         self.assertEqual(tris[0].texcoord_indices, [])
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/collada/tests/test_light.py
+++ b/collada/tests/test_light.py
@@ -12,10 +12,10 @@ class TestLight(unittest.TestCase):
         self.dummy = collada.Collada(validate_output=True)
 
     def test_directional_light_saving(self):
-        dirlight = collada.light.DirectionalLight("mydirlight", (1,1,1))
+        dirlight = collada.light.DirectionalLight("mydirlight", (1, 1, 1))
         self.assertEqual(dirlight.id, "mydirlight")
-        self.assertTupleEqual(dirlight.color, (1,1,1))
-        self.assertTupleEqual(tuple(dirlight.direction), (0,0,-1))
+        self.assertTupleEqual(dirlight.color, (1, 1, 1))
+        self.assertTupleEqual(tuple(dirlight.direction), (0, 0, -1))
         self.assertIsNotNone(str(dirlight))
         dirlight.color = (0.1, 0.2, 0.3)
         dirlight.id = "yourdirlight"
@@ -26,9 +26,9 @@ class TestLight(unittest.TestCase):
         self.assertEqual(loaded_dirlight.id, "yourdirlight")
 
     def test_ambient_light_saving(self):
-        ambientlight = collada.light.AmbientLight("myambientlight", (1,1,1))
+        ambientlight = collada.light.AmbientLight("myambientlight", (1, 1, 1))
         self.assertEqual(ambientlight.id, "myambientlight")
-        self.assertTupleEqual(ambientlight.color, (1,1,1))
+        self.assertTupleEqual(ambientlight.color, (1, 1, 1))
         self.assertIsNotNone(str(ambientlight))
         ambientlight.color = (0.1, 0.2, 0.3)
         ambientlight.id = "yourambientlight"
@@ -39,9 +39,9 @@ class TestLight(unittest.TestCase):
         self.assertEqual(ambientlight.id, "yourambientlight")
 
     def test_point_light_saving(self):
-        pointlight = collada.light.PointLight("mypointlight", (1,1,1))
+        pointlight = collada.light.PointLight("mypointlight", (1, 1, 1))
         self.assertEqual(pointlight.id, "mypointlight")
-        self.assertTupleEqual(pointlight.color, (1,1,1))
+        self.assertTupleEqual(pointlight.color, (1, 1, 1))
         self.assertEqual(pointlight.quad_att, None)
         self.assertEqual(pointlight.constant_att, None)
         self.assertEqual(pointlight.linear_att, None)
@@ -69,9 +69,9 @@ class TestLight(unittest.TestCase):
         self.assertEqual(loaded_pointlight.zfar, 0.2)
 
     def test_spot_light_saving(self):
-        spotlight = collada.light.SpotLight("myspotlight", (1,1,1))
+        spotlight = collada.light.SpotLight("myspotlight", (1, 1, 1))
         self.assertEqual(spotlight.id, "myspotlight")
-        self.assertTupleEqual(spotlight.color, (1,1,1))
+        self.assertTupleEqual(spotlight.color, (1, 1, 1))
         self.assertEqual(spotlight.constant_att, None)
         self.assertEqual(spotlight.linear_att, None)
         self.assertEqual(spotlight.quad_att, None)

--- a/collada/tests/test_lineset.py
+++ b/collada/tests/test_lineset.py
@@ -32,12 +32,12 @@ class TestLineset(unittest.TestCase):
         self.assertIn("requires vertex", e.exception.msg)
 
     def test_empty_lineset_saving(self):
-        linefloats = [1,1,-1, 1,-1,-1, -1,-0.9999998,-1, -0.9999997,1,-1, 1,0.9999995,1, 0.9999994,-1.000001,1]
+        linefloats = [1, 1, -1, 1, -1, -1, -1, -0.9999998, -1, -0.9999997, 1, -1, 1, 0.9999995, 1, 0.9999994, -1.000001, 1]
         linefloatsrc = collada.source.FloatSource("mylinevertsource", numpy.array(linefloats), ('X', 'Y', 'Z'))
         geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mygeometry", [linefloatsrc])
         input_list = collada.source.InputList()
         input_list.addInput(0, 'VERTEX', "#mylinevertsource")
-        indices = numpy.array([0,1, 1,2, 2,3, 3,4, 4,5])
+        indices = numpy.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5])
         lineset = geometry.createLineSet(indices, input_list, "mymaterial")
 
         # Check the initial values for the lineset.

--- a/collada/tests/test_material.py
+++ b/collada/tests/test_material.py
@@ -125,8 +125,6 @@ class TestMaterial(unittest.TestCase):
 
             numpy_uints = cimage.uintarray
             self.assertTupleEqual(numpy_uints.shape, (512, 512, 3))
-
-            cimage.floatarray
             self.assertTupleEqual(numpy_uints.shape, (512, 512, 3))
 
     def test_surface_saving(self):

--- a/collada/tests/test_material.py
+++ b/collada/tests/test_material.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import collada
 from collada.util import unittest
@@ -13,8 +12,8 @@ tostring = etree.tostring
 class TestMaterial(unittest.TestCase):
 
     def setUp(self):
-        self.dummy = collada.Collada(aux_file_loader = self.image_dummy_loader,
-                validate_output=True)
+        self.dummy = collada.Collada(aux_file_loader=self.image_dummy_loader,
+                                     validate_output=True)
 
         self.dummy_cimage = collada.material.CImage("yourcimage", "./whatever.tga", self.dummy)
         self.cimage = collada.material.CImage("mycimage", "./whatever.tga", self.dummy)
@@ -25,15 +24,15 @@ class TestMaterial(unittest.TestCase):
 
     def test_effect_saving(self):
         effect = collada.material.Effect("myeffect", [], "phong",
-                       emission = (0.1, 0.2, 0.3, 1.0),
-                       ambient = (0.4, 0.5, 0.6, 1.0),
-                       diffuse = (0.7, 0.8, 0.9, 0.5),
-                       specular = (0.3, 0.2, 0.1, 1.0),
-                       shininess = 0.4,
-                       reflective = (0.7, 0.6, 0.5, 1.0),
-                       reflectivity = 0.8,
-                       transparent = (0.2, 0.4, 0.6, 1.0),
-                       transparency = 0.9)
+                                         emission=(0.1, 0.2, 0.3, 1.0),
+                                         ambient=(0.4, 0.5, 0.6, 1.0),
+                                         diffuse=(0.7, 0.8, 0.9, 0.5),
+                                         specular=(0.3, 0.2, 0.1, 1.0),
+                                         shininess=0.4,
+                                         reflective=(0.7, 0.6, 0.5, 1.0),
+                                         reflectivity=0.8,
+                                         transparent=(0.2, 0.4, 0.6, 1.0),
+                                         transparency=0.9)
 
         self.assertEqual(effect.id, "myeffect")
         self.assertEqual(effect.shininess, 0.4)
@@ -64,7 +63,7 @@ class TestMaterial(unittest.TestCase):
         effect.save()
 
         loaded_effect = collada.material.Effect.load(self.dummy, {},
-                                    fromstring(tostring(effect.xmlnode)))
+                                                     fromstring(tostring(effect.xmlnode)))
 
         self.assertEqual(loaded_effect.id, "youreffect")
         self.assertEqual(loaded_effect.shininess, 7.0)
@@ -102,7 +101,7 @@ class TestMaterial(unittest.TestCase):
         self.assertIsNotNone(str(cimage))
 
     def test_cimage_data_loading(self):
-        data_dir = os.path.join(os.path.dirname(os.path.realpath( __file__ )), "data")
+        data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
         texture_file_path = os.path.join(data_dir, "duckCM.tga")
         self.assertTrue(os.path.isfile(texture_file_path), "Could not find data/duckCM.tga file for testing")
 
@@ -113,21 +112,21 @@ class TestMaterial(unittest.TestCase):
         cimage = collada.material.CImage("mycimage", "./whatever.tga", self.dummy)
         image_data = cimage.data
         self.assertEqual(len(image_data), 786476)
-        
+
         try:
             from PIL import Image as pil
         except ImportError:
             pil = None
-            
+
         if pil is not None:
             pil_image = cimage.pilimage
-            self.assertTupleEqual(pil_image.size, (512,512))
+            self.assertTupleEqual(pil_image.size, (512, 512))
             self.assertEqual(pil_image.format, "TGA")
 
             numpy_uints = cimage.uintarray
             self.assertTupleEqual(numpy_uints.shape, (512, 512, 3))
-    
-            numpy_floats = cimage.floatarray
+
+            cimage.floatarray
             self.assertTupleEqual(numpy_uints.shape, (512, 512, 3))
 
     def test_surface_saving(self):
@@ -154,7 +153,7 @@ class TestMaterial(unittest.TestCase):
         </surface>
         """
         self.assertRaises(collada.DaeIncompleteError, collada.material.Surface.load, self.dummy, {}, fromstring(surface1))
-        
+
         surface2 = """
         <newparam xmlns="http://www.collada.org/2005/11/COLLADASchema" sid="file1-surface">
         <surface xmlns="http://www.collada.org/2005/11/COLLADASchema" type="2D">
@@ -164,7 +163,7 @@ class TestMaterial(unittest.TestCase):
         </newparam>
         """
         self.assertRaises(collada.DaeBrokenRefError, collada.material.Surface.load, self.dummy, {}, fromstring(surface2))
-        
+
         surface3 = """
         <newparam xmlns="http://www.collada.org/2005/11/COLLADASchema" sid="file1-surface">
         <surface xmlns="http://www.collada.org/2005/11/COLLADASchema" type="2D">
@@ -196,7 +195,7 @@ class TestMaterial(unittest.TestCase):
         sampler2d.save()
 
         loaded_sampler2d = collada.material.Sampler2D.load(self.dummy,
-                                {'yoursurface':other_surface}, fromstring(tostring(sampler2d.xmlnode)))
+                                                           {'yoursurface': other_surface}, fromstring(tostring(sampler2d.xmlnode)))
         self.assertEqual(loaded_sampler2d.id, "yoursampler2d")
         self.assertEqual(loaded_sampler2d.surface.id, "yoursurface")
         self.assertEqual(loaded_sampler2d.minfilter, "QUADRATIC_MIPMAP_WHAT")
@@ -216,8 +215,11 @@ class TestMaterial(unittest.TestCase):
         map.texcoord = "TEX1"
         map.save()
 
-        loaded_map = collada.material.Map.load(self.dummy,
-                            {'yoursampler2d': other_sampler2d}, fromstring(tostring(map.xmlnode)))
+        loaded_map = collada.material.Map.load(
+            self.dummy,
+            {'yoursampler2d': other_sampler2d}, fromstring(tostring(map.xmlnode)))
+
+        assert loaded_map is not None
         self.assertEqual(map.sampler.id, "yoursampler2d")
         self.assertEqual(map.texcoord, "TEX1")
 
@@ -225,16 +227,16 @@ class TestMaterial(unittest.TestCase):
         surface = collada.material.Surface("mysurface", self.cimage)
         sampler2d = collada.material.Sampler2D("mysampler2d", surface)
         effect = collada.material.Effect("myeffect", [surface, sampler2d], "phong",
-                       emission = (0.1, 0.2, 0.3, 1.0),
-                       ambient = (0.4, 0.5, 0.6, 1.0),
-                       diffuse = (0.7, 0.8, 0.9, 1.0),
-                       specular = (0.3, 0.2, 0.1, 1.0),
-                       shininess = 0.4,
-                       reflective = (0.7, 0.6, 0.5, 1.0),
-                       reflectivity = 0.8,
-                       transparent = (0.2, 0.4, 0.6, 1.0),
-                       transparency = 0.9,
-                       opaque_mode = OPAQUE_MODE.A_ONE)
+                                         emission=(0.1, 0.2, 0.3, 1.0),
+                                         ambient=(0.4, 0.5, 0.6, 1.0),
+                                         diffuse=(0.7, 0.8, 0.9, 1.0),
+                                         specular=(0.3, 0.2, 0.1, 1.0),
+                                         shininess=0.4,
+                                         reflective=(0.7, 0.6, 0.5, 1.0),
+                                         reflectivity=0.8,
+                                         transparent=(0.2, 0.4, 0.6, 1.0),
+                                         transparency=0.9,
+                                         opaque_mode=OPAQUE_MODE.A_ONE)
 
         other_cimage = collada.material.CImage("yourcimage", "./whatever.tga", self.dummy)
         other_surface = collada.material.Surface("yoursurface", other_cimage)
@@ -252,27 +254,27 @@ class TestMaterial(unittest.TestCase):
         self.assertEqual(type(loaded_effect.diffuse), collada.material.Map)
         self.assertEqual(type(loaded_effect.transparent), collada.material.Map)
         self.assertEqual(len(loaded_effect.params), 3)
-        self.assertTrue(type(loaded_effect.params[0]) is collada.material.Surface)
+        self.assertTrue(isinstance(loaded_effect.params[0], collada.material.Surface))
         self.assertEqual(loaded_effect.params[0].id, "mysurface")
-        self.assertTrue(type(loaded_effect.params[1]) is collada.material.Surface)
+        self.assertTrue(isinstance(loaded_effect.params[1], collada.material.Surface))
         self.assertEqual(loaded_effect.params[1].id, "yoursurface")
-        self.assertTrue(type(loaded_effect.params[2]) is collada.material.Sampler2D)
+        self.assertTrue(isinstance(loaded_effect.params[2], collada.material.Sampler2D))
         self.assertEqual(loaded_effect.params[2].id, "yoursampler2d")
         self.assertEqual(loaded_effect.opaque_mode, OPAQUE_MODE.A_ONE)
 
     def test_rgbzero(self):
         effect = collada.material.Effect("myeffect", [], "phong",
-                       opaque_mode = OPAQUE_MODE.RGB_ZERO)
-        
+                                         opaque_mode=OPAQUE_MODE.RGB_ZERO)
+
         self.assertEqual(effect.opaque_mode, OPAQUE_MODE.RGB_ZERO)
         self.assertEqual(effect.transparency, 0.0)
         effect.save()
-        
+
         loaded_effect = collada.material.Effect.load(self.dummy, {}, fromstring(tostring(effect.xmlnode)))
         self.assertEqual(loaded_effect.opaque_mode, OPAQUE_MODE.RGB_ZERO)
-        
+
         effect = collada.material.Effect("myeffect", [], "phong")
-        
+
         self.assertEqual(effect.opaque_mode, OPAQUE_MODE.A_ONE)
         self.assertEqual(effect.transparency, 1.0)
         effect.save()
@@ -295,6 +297,6 @@ class TestMaterial(unittest.TestCase):
         self.assertEqual(loaded_mat.name, "yourmat")
         self.assertEqual(loaded_mat.effect.id, self.othereffect.id)
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/collada/tests/test_scene.py
+++ b/collada/tests/test_scene.py
@@ -16,7 +16,7 @@ class TestScene(unittest.TestCase):
         self.yourcam = collada.camera.PerspectiveCamera("yourcam", 45.0, 0.01, 1000.0)
         self.dummy.cameras.append(self.yourcam)
 
-        self.yourdirlight = collada.light.DirectionalLight("yourdirlight", (1,1,1))
+        self.yourdirlight = collada.light.DirectionalLight("yourdirlight", (1, 1, 1))
         self.dummy.lights.append(self.yourdirlight)
 
         cimage = collada.material.CImage("mycimage", "./whatever.tga", self.dummy)
@@ -24,25 +24,25 @@ class TestScene(unittest.TestCase):
         sampler2d = collada.material.Sampler2D("mysampler2d", surface)
         mymap = collada.material.Map(sampler2d, "TEX0")
         self.effect = collada.material.Effect("myeffect", [surface, sampler2d], "phong",
-                       emission = (0.1, 0.2, 0.3),
-                       ambient = (0.4, 0.5, 0.6),
-                       diffuse = mymap,
-                       specular = (0.3, 0.2, 0.1))
+                                              emission=(0.1, 0.2, 0.3),
+                                              ambient=(0.4, 0.5, 0.6),
+                                              diffuse=mymap,
+                                              specular=(0.3, 0.2, 0.1))
         self.effect2 = collada.material.Effect("youreffect", [], "phong",
-                       emission = (0.1, 0.2, 0.3),
-                       ambient = (0.4, 0.5, 0.6),
-                       specular = (0.3, 0.2, 0.1))
+                                               emission=(0.1, 0.2, 0.3),
+                                               ambient=(0.4, 0.5, 0.6),
+                                               specular=(0.3, 0.2, 0.1))
         self.dummy.materials.append(self.effect)
         self.dummy.materials.append(self.effect2)
 
-        self.floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1,0.2,0.3]), ('X', 'Y', 'Z'))
-        self.geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mygeometry", {"myfloatsource":self.floatsource})
-        self.geometry2 = collada.geometry.Geometry(self.dummy, "geometry1", "yourgeometry", {"myfloatsource":self.floatsource})
+        self.floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1, 0.2, 0.3]), ('X', 'Y', 'Z'))
+        self.geometry = collada.geometry.Geometry(self.dummy, "geometry0", "mygeometry", {"myfloatsource": self.floatsource})
+        self.geometry2 = collada.geometry.Geometry(self.dummy, "geometry1", "yourgeometry", {"myfloatsource": self.floatsource})
         self.dummy.geometries.append(self.geometry)
         self.dummy.geometries.append(self.geometry2)
 
     def test_scene_light_node_saving(self):
-        dirlight = collada.light.DirectionalLight("mydirlight", (1,1,1))
+        dirlight = collada.light.DirectionalLight("mydirlight", (1, 1, 1))
         lightnode = collada.scene.LightNode(dirlight)
         bindtest = list(lightnode.objects('light'))
         self.assertEqual(lightnode.light, dirlight)
@@ -107,16 +107,16 @@ class TestScene(unittest.TestCase):
         self.assertAlmostEqual(loaded_scale.z, 0.3)
 
     def test_scene_matrix_node(self):
-        matrix = collada.scene.MatrixTransform(numpy.array([1.0,0,0,2, 0,1,0,3, 0,0,1,4, 0,0,0,1]))
+        matrix = collada.scene.MatrixTransform(numpy.array([1.0, 0, 0, 2, 0, 1, 0, 3, 0, 0, 1, 4, 0, 0, 0, 1]))
         self.assertAlmostEqual(matrix.matrix[0][0], 1.0)
         self.assertIsNotNone(str(matrix))
         loaded_matrix = collada.scene.MatrixTransform.load(self.dummy, fromstring(tostring(matrix.xmlnode)))
         self.assertAlmostEqual(loaded_matrix.matrix[0][0], 1.0)
 
     def test_scene_lookat_node(self):
-        eye = numpy.array([2.0,0,3])
-        interest = numpy.array([0.0,0,0])
-        upvector = numpy.array([0.0,1,0])
+        eye = numpy.array([2.0, 0, 3])
+        interest = numpy.array([0.0, 0, 0])
+        upvector = numpy.array([0.0, 1, 0])
         lookat = collada.scene.LookAtTransform(eye, interest, upvector)
         self.assertListEqual(list(lookat.eye), list(eye))
         self.assertListEqual(list(lookat.interest), list(interest))
@@ -159,7 +159,7 @@ class TestScene(unittest.TestCase):
         self.assertEqual(both.transforms[0], scale)
         self.assertEqual(both.children[0], justchildren)
         self.assertEqual(both.children[1], justtransform)
-        loadedboth = collada.scene.Node.load(self.dummy, fromstring(tostring(both.xmlnode)), {})
+        collada.scene.Node.load(self.dummy, fromstring(tostring(both.xmlnode)), {})
         self.assertEqual(len(both.children), 2)
         self.assertEqual(len(both.transforms), 1)
 
@@ -189,8 +189,8 @@ class TestScene(unittest.TestCase):
         self.assertEqual(len(yournode.transforms), 2)
         self.assertEqual(yournode.children[0].id, 'myemptynode')
         self.assertEqual(yournode.children[1].id, 'youremptynode')
-        self.assertTrue(type(yournode.transforms[0]) is collada.scene.ScaleTransform)
-        self.assertTrue(type(yournode.transforms[1]) is collada.scene.TranslateTransform)
+        self.assertTrue(isinstance(yournode.transforms[0], collada.scene.ScaleTransform))
+        self.assertTrue(isinstance(yournode.transforms[1], collada.scene.TranslateTransform))
 
         translate = collada.scene.TranslateTransform(0.1, 0.2, 0.3)
         mynode.transforms.append(translate)
@@ -204,7 +204,7 @@ class TestScene(unittest.TestCase):
         yournode = collada.scene.Node.load(self.dummy, fromstring(tostring(mynode.xmlnode)), {})
         self.assertEqual(yournode.id, 'yournode')
         self.assertEqual(yournode.name, 'yourname')
-        
+
         myemptynode = collada.scene.Node('myemptynode')
         rotate = collada.scene.RotateTransform(0.1, 0.2, 0.3, 90)
         scale = collada.scene.ScaleTransform(0.1, 0.2, 0.3)
@@ -214,7 +214,6 @@ class TestScene(unittest.TestCase):
         mynode = collada.scene.Node('othernode', children=[myemptynode], transforms=[rotate, scale], name='othername')
         self.assertEqual(mynode.id, 'othernode')
         self.assertEqual(mynode.name, 'othername')
-        
 
     def test_scene_material_node(self):
         binding1 = ("TEX0", "TEXCOORD", "0")
@@ -305,8 +304,8 @@ class TestScene(unittest.TestCase):
         self.assertEqual(yournode.children[0].geometry.id, self.geometry.id)
         self.assertEqual(yournode.children[1].camera.id, self.yourcam.id)
         self.assertEqual(yournode.children[2].light.id, self.yourdirlight.id)
-        self.assertTrue(type(yournode.transforms[0]) is collada.scene.RotateTransform)
-        self.assertTrue(type(yournode.transforms[1]) is collada.scene.ScaleTransform)
+        self.assertTrue(isinstance(yournode.transforms[0], collada.scene.RotateTransform))
+        self.assertTrue(isinstance(yournode.transforms[1], collada.scene.ScaleTransform))
 
     def test_scene_with_nodes(self):
         rotate = collada.scene.RotateTransform(0.1, 0.2, 0.3, 90)
@@ -335,6 +334,7 @@ class TestScene(unittest.TestCase):
         self.assertEqual(loaded_scene.nodes[0].id, 'mynode')
         self.assertEqual(loaded_scene.nodes[1].id, 'othernode')
         self.assertEqual(loaded_scene.nodes[2].id, 'anothernode')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/collada/tests/test_source.py
+++ b/collada/tests/test_source.py
@@ -14,7 +14,7 @@ class TestSource(unittest.TestCase):
         self.dummy = collada.Collada(validate_output=True)
 
     def test_float_source_saving(self):
-        floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1,0.2,0.3]), ('X', 'Y', 'X'))
+        floatsource = collada.source.FloatSource("myfloatsource", numpy.array([0.1, 0.2, 0.3]), ('X', 'Y', 'X'))
         self.assertEqual(floatsource.id, "myfloatsource")
         self.assertEqual(len(floatsource), 1)
         self.assertTupleEqual(floatsource.components, ('X', 'Y', 'X'))
@@ -31,8 +31,8 @@ class TestSource(unittest.TestCase):
 
     def test_idref_source_saving(self):
         idrefsource = collada.source.IDRefSource("myidrefsource",
-                                numpy.array(['Ref1', 'Ref2'], dtype=numpy.string_),
-                                ('MORPH_TARGET',))
+                                                 numpy.array(['Ref1', 'Ref2'], dtype=numpy.string_),
+                                                 ('MORPH_TARGET',))
         self.assertEqual(idrefsource.id, "myidrefsource")
         self.assertEqual(len(idrefsource), 2)
         self.assertTupleEqual(idrefsource.components, ('MORPH_TARGET',))
@@ -49,8 +49,8 @@ class TestSource(unittest.TestCase):
 
     def test_name_source_saving(self):
         namesource = collada.source.NameSource("mynamesource",
-                                numpy.array(['Name1', 'Name2'], dtype=numpy.string_),
-                                ('JOINT',))
+                                               numpy.array(['Name1', 'Name2'], dtype=numpy.string_),
+                                               ('JOINT',))
         self.assertEqual(namesource.id, "mynamesource")
         self.assertEqual(len(namesource), 2)
         self.assertTupleEqual(namesource.components, ('JOINT',))
@@ -64,6 +64,7 @@ class TestSource(unittest.TestCase):
         self.assertEqual(loaded_namesource.id, "yournamesource")
         self.assertEqual(len(loaded_namesource), 3)
         self.assertTupleEqual(loaded_namesource.components, ('WEIGHT', 'WHATEVER'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/collada/triangleset.py
+++ b/collada/triangleset.py
@@ -15,17 +15,16 @@
 import numpy
 
 from collada import primitive
-from collada.common import E, tag
-from collada.common import DaeIncompleteError, DaeBrokenRefError, \
-        DaeMalformedError, DaeUnsupportedError
+from collada.common import E
+from collada.common import DaeIncompleteError, DaeMalformedError
 from collada.util import toUnitVec, checkSource, normalize_v3, dot_v3, xrange
-from collada.xmlutil import etree as ElementTree
 
 
 class Triangle(object):
     """Single triangle representation."""
+
     def __init__(self, indices, vertices, normal_indices, normals,
-            texcoord_indices, texcoords, material):
+                 texcoord_indices, texcoords, material):
         """A triangle should not be created manually."""
 
         self.vertices = vertices
@@ -52,7 +51,7 @@ class Triangle(object):
            vertices in the texcoord array."""
 
         if self.normals is None:
-            #generate normals
+            # generate normals
             vec1 = numpy.subtract(vertices[0], vertices[1])
             vec2 = numpy.subtract(vertices[2], vertices[0])
             vec3 = toUnitVec(numpy.cross(toUnitVec(vec2), toUnitVec(vec1)))
@@ -60,8 +59,9 @@ class Triangle(object):
 
     def __repr__(self):
         return '<Triangle (%s, %s, %s, "%s")>' % (str(self.vertices[0]),
-                str(self.vertices[1]), str(self.vertices[2]),
-                str(self.material))
+                                                  str(self.vertices[1]), str(self.vertices[2]),
+                                                  str(self.material))
+
     def __str__(self):
         return repr(self)
 
@@ -85,10 +85,10 @@ class TriangleSet(primitive.Primitive):
 
         if len(sources) == 0:
             raise DaeIncompleteError('A triangle set needs at least one input for vertex positions')
-        if not 'VERTEX' in sources:
+        if 'VERTEX' not in sources:
             raise DaeIncompleteError('Triangle set requires vertex input')
 
-        max_offset = max([ max([input[0] for input in input_type_array])
+        max_offset = max([max([input[0] for input in input_type_array])
                           for input_type_array in sources.values()
                           if len(input_type_array) > 0])
 
@@ -102,8 +102,8 @@ class TriangleSet(primitive.Primitive):
 
         if len(self.index) > 0:
             self._vertex = sources['VERTEX'][0][4].data
-            self._vertex_index = self.index[:,:, sources['VERTEX'][0][0]]
-            self.maxvertexindex = numpy.max( self._vertex_index )
+            self._vertex_index = self.index[:, :, sources['VERTEX'][0][0]]
+            self.maxvertexindex = numpy.max(self._vertex_index)
             checkSource(sources['VERTEX'][0][4], ('X', 'Y', 'Z'), self.maxvertexindex)
         else:
             self._vertex = None
@@ -112,8 +112,8 @@ class TriangleSet(primitive.Primitive):
 
         if 'NORMAL' in sources and len(sources['NORMAL']) > 0 and len(self.index) > 0:
             self._normal = sources['NORMAL'][0][4].data
-            self._normal_index = self.index[:,:, sources['NORMAL'][0][0]]
-            self.maxnormalindex = numpy.max( self._normal_index )
+            self._normal_index = self.index[:, :, sources['NORMAL'][0][0]]
+            self.maxnormalindex = numpy.max(self._normal_index)
             checkSource(sources['NORMAL'][0][4], ('X', 'Y', 'Z'), self.maxnormalindex)
         else:
             self._normal = None
@@ -122,9 +122,9 @@ class TriangleSet(primitive.Primitive):
 
         if 'TEXCOORD' in sources and len(sources['TEXCOORD']) > 0 and len(self.index) > 0:
             self._texcoordset = tuple([texinput[4].data for texinput in sources['TEXCOORD']])
-            self._texcoord_indexset = tuple([ self.index[:,:, sources['TEXCOORD'][i][0]]
-                                             for i in xrange(len(sources['TEXCOORD'])) ])
-            self.maxtexcoordsetindex = [ numpy.max( tex_index ) for tex_index in self._texcoord_indexset ]
+            self._texcoord_indexset = tuple([self.index[:, :, sources['TEXCOORD'][i][0]]
+                                             for i in xrange(len(sources['TEXCOORD']))])
+            self.maxtexcoordsetindex = [numpy.max(tex_index) for tex_index in self._texcoord_indexset]
             for i, texinput in enumerate(sources['TEXCOORD']):
                 checkSource(texinput[4], ('S', 'T'), self.maxtexcoordsetindex[i])
         else:
@@ -134,9 +134,9 @@ class TriangleSet(primitive.Primitive):
 
         if 'TEXTANGENT' in sources and len(sources['TEXTANGENT']) > 0 and len(self.index) > 0:
             self._textangentset = tuple([texinput[4].data for texinput in sources['TEXTANGENT']])
-            self._textangent_indexset = tuple([ self.index[:,:, sources['TEXTANGENT'][i][0]]
-                                             for i in xrange(len(sources['TEXTANGENT'])) ])
-            self.maxtextangentsetindex = [ numpy.max( tex_index ) for tex_index in self._textangent_indexset ]
+            self._textangent_indexset = tuple([self.index[:, :, sources['TEXTANGENT'][i][0]]
+                                               for i in xrange(len(sources['TEXTANGENT']))])
+            self.maxtextangentsetindex = [numpy.max(tex_index) for tex_index in self._textangent_indexset]
             for i, texinput in enumerate(sources['TEXTANGENT']):
                 checkSource(texinput[4], ('X', 'Y', 'Z'), self.maxtextangentsetindex[i])
         else:
@@ -146,9 +146,9 @@ class TriangleSet(primitive.Primitive):
 
         if 'TEXBINORMAL' in sources and len(sources['TEXBINORMAL']) > 0 and len(self.index) > 0:
             self._texbinormalset = tuple([texinput[4].data for texinput in sources['TEXBINORMAL']])
-            self._texbinormal_indexset = tuple([ self.index[:,:, sources['TEXBINORMAL'][i][0]]
-                                             for i in xrange(len(sources['TEXBINORMAL'])) ])
-            self.maxtexbinormalsetindex = [ numpy.max( tex_index ) for tex_index in self._texbinormal_indexset ]
+            self._texbinormal_indexset = tuple([self.index[:, :, sources['TEXBINORMAL'][i][0]]
+                                                for i in xrange(len(sources['TEXBINORMAL']))])
+            self.maxtexbinormalsetindex = [numpy.max(tex_index) for tex_index in self._texbinormal_indexset]
             for i, texinput in enumerate(sources['TEXBINORMAL']):
                 checkSource(texinput[4], ('X', 'Y', 'Z'), self.maxtexbinormalsetindex[i])
         else:
@@ -156,7 +156,8 @@ class TriangleSet(primitive.Primitive):
             self._texbinormal_indexset = tuple()
             self.maxtexbinormalsetindex = -1
 
-        if xmlnode is not None: self.xmlnode = xmlnode
+        if xmlnode is not None:
+            self.xmlnode = xmlnode
         else:
             self._recreateXmlNode()
 
@@ -165,7 +166,7 @@ class TriangleSet(primitive.Primitive):
 
     def _recreateXmlNode(self):
         self.index.shape = (-1)
-        acclen = len(self.index)
+        len(self.index)
         txtindices = ' '.join(map(str, self.index.tolist()))
         self.index.shape = (-1, 3, self.nindices)
 
@@ -185,19 +186,20 @@ class TriangleSet(primitive.Primitive):
         self.xmlnode.append(E.p(txtindices))
 
     def __getitem__(self, i):
-        v = self._vertex[ self._vertex_index[i] ]
-        n = self._normal[ self._normal_index[i] ] if self._normal is not None else None
+        v = self._vertex[self._vertex_index[i]]
+        n = self._normal[self._normal_index[i]] if self._normal is not None else None
         uvindices = []
         uv = []
         for j, uvindex in enumerate(self._texcoord_indexset):
-            uvindices.append( uvindex[i] )
-            uv.append( self._texcoordset[j][ uvindex[i] ] )
+            uvindices.append(uvindex[i])
+            uv.append(self._texcoordset[j][uvindex[i]])
         return Triangle(self._vertex_index[i], v, self._normal_index[i] if self._normal_index is not None else 0, n, uvindices, uv, self.material)
 
     @staticmethod
-    def load( collada, localscope, node ):
+    def load(collada, localscope, node):
         indexnodes = node.findall(collada.tag('p'))
-        if not indexnodes: raise DaeIncompleteError('Missing index in triangle set')
+        if not indexnodes:
+            raise DaeIncompleteError('Missing index in triangle set')
 
         source_array = primitive.Primitive._getInputs(collada, localscope, node.findall(collada.tag('input')))
 
@@ -211,9 +213,9 @@ class TriangleSet(primitive.Primitive):
 
         indexlist = []
         tag_bare = node.tag.split('}')[-1]
-         
+
         extendfunc = _indexExtendFunctions[tag_bare]
-        
+
         max_offset = max(input[0] for input_type_array in source_array.values()
                          for input in input_type_array)
 
@@ -226,7 +228,7 @@ class TriangleSet(primitive.Primitive):
                 extendfunc(indexlist, index.reshape((-1, max_offset + 1)))
             else:
                 index = numpy.concatenate(indexlist)
-        except:
+        except BaseException:
             raise DaeMalformedError('Corrupted index in triangleset')
 
         triset = TriangleSet(source_array, node.get('material'), index, node)
@@ -235,18 +237,18 @@ class TriangleSet(primitive.Primitive):
 
     def bind(self, matrix, materialnodebysymbol):
         """Create a bound triangle set from this triangle set, transform and material mapping"""
-        return BoundTriangleSet( self, matrix, materialnodebysymbol)
+        return BoundTriangleSet(self, matrix, materialnodebysymbol)
 
     def generateNormals(self):
         """If :attr:`normals` is `None` or you wish for normals to be
         recomputed, call this method to recompute them."""
-        norms = numpy.zeros( self._vertex.shape, dtype=self._vertex.dtype )
+        norms = numpy.zeros(self._vertex.shape, dtype=self._vertex.dtype)
         tris = self._vertex[self._vertex_index]
-        n = numpy.cross( tris[::,1] - tris[::,0], tris[::,2] - tris[::,0] )
+        n = numpy.cross(tris[::, 1] - tris[::, 0], tris[::, 2] - tris[::, 0])
         normalize_v3(n)
-        norms[ self._vertex_index[:,0] ] += n
-        norms[ self._vertex_index[:,1] ] += n
-        norms[ self._vertex_index[:,2] ] += n
+        norms[self._vertex_index[:, 0]] += n
+        norms[self._vertex_index[:, 1]] += n
+        norms[self._vertex_index[:, 2]] += n
         normalize_v3(norms)
 
         self._normal = norms
@@ -256,24 +258,24 @@ class TriangleSet(primitive.Primitive):
         """If there are no texture tangents, this method will compute them.
         Texture coordinates must exist and it uses the first texture coordinate set."""
 
-        #The following is taken from:
+        # The following is taken from:
         # http://www.terathon.com/code/tangent.html
         # It's pretty much a direct translation, using numpy arrays
 
         tris = self._vertex[self._vertex_index]
         uvs = self._texcoordset[0][self._texcoord_indexset[0]]
 
-        x1 = tris[:,1,0]-tris[:,0,0]
-        x2 = tris[:,2,0]-tris[:,1,0]
-        y1 = tris[:,1,1]-tris[:,0,1]
-        y2 = tris[:,2,1]-tris[:,1,1]
-        z1 = tris[:,1,2]-tris[:,0,2]
-        z2 = tris[:,2,2]-tris[:,1,2]
+        x1 = tris[:, 1, 0] - tris[:, 0, 0]
+        x2 = tris[:, 2, 0] - tris[:, 1, 0]
+        y1 = tris[:, 1, 1] - tris[:, 0, 1]
+        y2 = tris[:, 2, 1] - tris[:, 1, 1]
+        z1 = tris[:, 1, 2] - tris[:, 0, 2]
+        z2 = tris[:, 2, 2] - tris[:, 1, 2]
 
-        s1 = uvs[:,1,0]-uvs[:,0,0]
-        s2 = uvs[:,2,0]-uvs[:,1,0]
-        t1 = uvs[:,1,1]-uvs[:,0,1]
-        t2 = uvs[:,2,1]-uvs[:,1,1]
+        s1 = uvs[:, 1, 0] - uvs[:, 0, 0]
+        s2 = uvs[:, 2, 0] - uvs[:, 1, 0]
+        t1 = uvs[:, 1, 1] - uvs[:, 0, 1]
+        t2 = uvs[:, 2, 1] - uvs[:, 1, 1]
 
         r = 1.0 / (s1 * t2 - s2 * t1)
 
@@ -282,20 +284,20 @@ class TriangleSet(primitive.Primitive):
         sdirz = (t2 * z1 - t1 * z2) * r
         sdir = numpy.vstack((sdirx, sdiry, sdirz)).T
 
-        tans1 = numpy.zeros( self._vertex.shape, dtype=self._vertex.dtype )
-        tans1[ self._vertex_index[:,0] ] += sdir
-        tans1[ self._vertex_index[:,1] ] += sdir
-        tans1[ self._vertex_index[:,2] ] += sdir
+        tans1 = numpy.zeros(self._vertex.shape, dtype=self._vertex.dtype)
+        tans1[self._vertex_index[:, 0]] += sdir
+        tans1[self._vertex_index[:, 1]] += sdir
+        tans1[self._vertex_index[:, 2]] += sdir
 
         norm = self._normal[self._normal_index]
         norm.shape = (-1, 3)
         tan1 = tans1[self._vertex_index]
         tan1.shape = (-1, 3)
 
-        tangent = normalize_v3(tan1 - norm * dot_v3(norm, tan1)[:,numpy.newaxis])
+        tangent = normalize_v3(tan1 - norm * dot_v3(norm, tan1)[:, numpy.newaxis])
 
         self._textangentset = (tangent,)
-        self._textangent_indexset = (numpy.arange(len(self._vertex_index)*3, dtype=self._vertex_index.dtype),)
+        self._textangent_indexset = (numpy.arange(len(self._vertex_index) * 3, dtype=self._vertex_index.dtype),)
         self._textangent_indexset[0].shape = (len(self._vertex_index), 3)
 
         tdirx = (s1 * x2 - s2 * x1) * r
@@ -303,10 +305,10 @@ class TriangleSet(primitive.Primitive):
         tdirz = (s1 * z2 - s2 * z1) * r
         tdir = numpy.vstack((tdirx, tdiry, tdirz)).T
 
-        tans2 = numpy.zeros( self._vertex.shape, dtype=self._vertex.dtype )
-        tans2[ self._vertex_index[:,0] ] += tdir
-        tans2[ self._vertex_index[:,1] ] += tdir
-        tans2[ self._vertex_index[:,2] ] += tdir
+        tans2 = numpy.zeros(self._vertex.shape, dtype=self._vertex.dtype)
+        tans2[self._vertex_index[:, 0]] += tdir
+        tans2[self._vertex_index[:, 1]] += tdir
+        tans2[self._vertex_index[:, 2]] += tdir
 
         tan2 = tans2[self._vertex_index]
         tan2.shape = (-1, 3)
@@ -316,11 +318,11 @@ class TriangleSet(primitive.Primitive):
 
         binorm = numpy.cross(norm, tangent).flatten()
         binorm.shape = (-1, 3)
-        binorm = binorm * tanw[:,numpy.newaxis]
+        binorm = binorm * tanw[:, numpy.newaxis]
 
         self._texbinormalset = (binorm,)
         self._texbinormal_indexset = (numpy.arange(len(self._vertex_index) * 3,
-            dtype=self._vertex_index.dtype),)
+                                                   dtype=self._vertex_index.dtype),)
         self._texbinormal_indexset[0].shape = (len(self._vertex_index), 3)
 
     def __str__(self):
@@ -342,16 +344,17 @@ class BoundTriangleSet(primitive.BoundPrimitive):
         """Create a bound triangle set from a triangle set, transform and material mapping.
         This gets created when a triangle set is instantiated in a scene. Do not create this manually."""
         M = numpy.asmatrix(matrix).transpose()
-        self._vertex = None if ts.vertex is None else numpy.asarray(ts._vertex * M[:3,:3]) + matrix[:3,3]
-        self._normal = None if ts._normal is None else numpy.asarray(ts._normal * M[:3,:3])
+        self._vertex = None if ts.vertex is None else numpy.asarray(ts._vertex * M[:3, :3]) + matrix[:3, 3]
+        self._normal = None if ts._normal is None else numpy.asarray(ts._normal * M[:3, :3])
         self._texcoordset = ts._texcoordset
         self._textangentset = ts._textangentset
         self._texbinormalset = ts._texbinormalset
-        matnode = materialnodebysymbol.get( ts.material )
+        matnode = materialnodebysymbol.get(ts.material)
         if matnode:
             self.material = matnode.target
-            self.inputmap = dict([ (sem, (input_sem, set)) for sem, input_sem, set in matnode.inputs ])
-        else: self.inputmap = self.material = None
+            self.inputmap = dict([(sem, (input_sem, set)) for sem, input_sem, set in matnode.inputs])
+        else:
+            self.inputmap = self.material = None
         self.index = ts.index
         self._vertex_index = ts._vertex_index
         self._normal_index = ts._normal_index
@@ -388,7 +391,8 @@ class BoundTriangleSet(primitive.BoundPrimitive):
 
         :rtype: generator of :class:`collada.triangleset.Triangle`
         """
-        for i in xrange(self.ntriangles): yield self[i]
+        for i in xrange(self.ntriangles):
+            yield self[i]
 
     def shapes(self):
         """Iterate through all the triangles contained in the set.
@@ -400,13 +404,13 @@ class BoundTriangleSet(primitive.BoundPrimitive):
     def generateNormals(self):
         """If :attr:`normals` is `None` or you wish for normals to be
         recomputed, call this method to recompute them."""
-        norms = numpy.zeros( self._vertex.shape, dtype=self._vertex.dtype )
+        norms = numpy.zeros(self._vertex.shape, dtype=self._vertex.dtype)
         tris = self._vertex[self._vertex_index]
-        n = numpy.cross( tris[::,1] - tris[::,0], tris[::,2] - tris[::,0] )
+        n = numpy.cross(tris[::, 1] - tris[::, 0], tris[::, 2] - tris[::, 0])
         normalize_v3(n)
-        norms[ self._vertex_index[:,0] ] += n
-        norms[ self._vertex_index[:,1] ] += n
-        norms[ self._vertex_index[:,2] ] += n
+        norms[self._vertex_index[:, 0]] += n
+        norms[self._vertex_index[:, 1]] += n
+        norms[self._vertex_index[:, 2]] += n
         normalize_v3(norms)
 
         self._normal = norms
@@ -432,6 +436,7 @@ def _extendFromStrip(indexlist, index):
     indexlist.append(cw_.swapaxes(0, 1).ravel())
     indexlist.append(ccw.swapaxes(0, 1).ravel())
 
+
 def _extendFromFan(indexlist, index):
     """Convert triangle fan indices to triangle indices
     """
@@ -440,6 +445,7 @@ def _extendFromFan(indexlist, index):
         index[1:-1],
         index[2:]), 1)
     indexlist.append(c.reshape(-1))
+
 
 _indexExtendFunctions = {
     'tristrips': _extendFromStrip,

--- a/collada/util.py
+++ b/collada/util.py
@@ -21,7 +21,7 @@ if sys.version_info[0] > 2:
     from io import StringIO, BytesIO
 
     bytes = bytes
-    basestring = (str,bytes)
+    basestring = (str, bytes)
     xrange = range
 else:
     import unittest
@@ -31,6 +31,7 @@ else:
     from StringIO import StringIO
 
     BytesIO = StringIO
+
     def bytes(s, encoding='utf-8'):
         return s
     basestring = basestring
@@ -58,6 +59,7 @@ def falmostEqual(a, b, rtol=1.0000000000000001e-05, atol=1e-08):
 
     return math.fabs(a - b) <= (atol + rtol * math.fabs(b))
 
+
 def toUnitVec(vec):
     """Converts the given vector to a unit vector
 
@@ -69,7 +71,8 @@ def toUnitVec(vec):
     """
     return vec / numpy.sqrt(numpy.vdot(vec, vec))
 
-def checkSource( source, components, maxindex):
+
+def checkSource(source, components, maxindex):
     """Check if a source objects complies with the needed `components` and has the needed length
 
     :param collada.source.Source source:
@@ -83,17 +86,18 @@ def checkSource( source, components, maxindex):
     if len(source.data) <= maxindex:
         raise DaeMalformedError(
             "Indexes (maxindex=%d) for source '%s' (len=%d) go beyond the limits of the source"
-            % (maxindex, source.id, len(source.data)) )
+            % (maxindex, source.id, len(source.data)))
 
-    #some files will write sources with no named parameters
-    #by spec, these params should just be skipped, but we need to
-    #adapt to the failed output of others...
+    # some files will write sources with no named parameters
+    # by spec, these params should just be skipped, but we need to
+    # adapt to the failed output of others...
     if len(source.components) == len(components):
         source.components = components
 
     if source.components != components:
-        raise DaeMalformedError('Wrong format in source %s'%source.id)
+        raise DaeMalformedError('Wrong format in source %s' % source.id)
     return source
+
 
 def normalize_v3(arr):
     """Normalize a numpy array of 3 component vectors with shape (N,3)
@@ -104,12 +108,13 @@ def normalize_v3(arr):
     :rtype: numpy.array
 
     """
-    lens = numpy.sqrt( arr[:,0]**2 + arr[:,1]**2 + arr[:,2]**2 )
+    lens = numpy.sqrt(arr[:, 0]**2 + arr[:, 1]**2 + arr[:, 2]**2)
     lens[numpy.equal(lens, 0)] = 1
-    arr[:,0] /= lens
-    arr[:,1] /= lens
-    arr[:,2] /= lens
+    arr[:, 0] /= lens
+    arr[:, 1] /= lens
+    arr[:, 2] /= lens
     return arr
+
 
 def dot_v3(arr1, arr2):
     """Calculates the dot product for each vector in two arrays
@@ -122,7 +127,8 @@ def dot_v3(arr1, arr2):
     :rtype: numpy.array
 
     """
-    return arr1[:,0]*arr2[:,0] + arr1[:,1]*arr2[:,1] + arr2[:,2]*arr1[:,2]
+    return arr1[:, 0] * arr2[:, 0] + arr1[:, 1] * arr2[:, 1] + arr2[:, 2] * arr1[:, 2]
+
 
 class IndexedList(list):
     """
@@ -139,6 +145,7 @@ class IndexedList(list):
        L[0] # = o
        L['test'] # = o
     """
+
     def __init__(self, items, attrs):
         super(IndexedList, self).__init__(items)
         # do indexing
@@ -246,7 +253,7 @@ class IndexedList(list):
         self._addindex(new_obj)
         return list.insert(self, ind, new_obj)
 
-    def pop(self, ind= -1):
+    def pop(self, ind=-1):
         # ensure that ind is a numeric index
         try:
             obj = list.__getitem__(self, ind)
@@ -266,12 +273,12 @@ class IndexedList(list):
         self._delindex(obj)
         return list.remove(self, ind)
 
+
 def _correctValInNode(outernode, tagname, value):
-    innernode = outernode.find( tag(tagname) )
+    innernode = outernode.find(tag(tagname))
     if value is None and innernode is not None:
         outernode.remove(innernode)
     elif innernode is not None:
         innernode.text = str(value)
     elif value is not None:
         outernode.append(E(tagname, str(value)))
-

--- a/collada/xmlutil.py
+++ b/collada/xmlutil.py
@@ -1,4 +1,3 @@
-import sys
 import functools
 
 COLLADA_NS = 'http://www.collada.org/2005/11/COLLADASchema'
@@ -38,21 +37,21 @@ except (NameError, KeyError):
 
 if HAVE_LXML:
     from lxml.builder import E, ElementMaker
-    
+
     def writeXML(xmlnode, fp):
         xmlnode.write(fp, pretty_print=True)
-else:    
+else:
     class ElementMaker(object):
         def __init__(self, namespace=None, nsmap=None):
             if namespace is not None:
                 self._namespace = '{' + namespace + '}'
             else:
                 self._namespace = None
-        
+
         def __call__(self, tag, *children, **attrib):
             if self._namespace is not None and tag[0] != '{':
                 tag = self._namespace + tag
-            
+
             elem = etree.Element(tag, attrib)
             for item in children:
                 if isinstance(item, dict):
@@ -67,15 +66,15 @@ else:
                 else:
                     raise TypeError("bad argument: %r" % item)
             return elem
-    
+
         def __getattr__(self, tag):
             return functools.partial(self, tag)
 
     E = ElementMaker()
-    
+
     if etree.VERSION[0:3] == '1.2':
-        #in etree < 1.3, this is a workaround for suppressing prefixes
-        
+        # in etree < 1.3, this is a workaround for suppressing prefixes
+
         def fixtag(tag, namespaces):
             import string
             # given a decorated tag (of the form {uri}tag), return prefixed
@@ -103,24 +102,24 @@ else:
                 prefix += ":"
             else:
                 prefix = ''
-                
+
             return "%s%s" % (prefix, tag), xmlns
-    
+
         etree.fixtag = fixtag
         etree._namespace_map[COLLADA_NS] = None
     else:
-        #For etree > 1.3, use register_namespace function
+        # For etree > 1.3, use register_namespace function
         etree.register_namespace('', COLLADA_NS)
 
     def indent(elem, level=0):
-        i = "\n" + level*"  "
+        i = "\n" + level * "  "
         if len(elem):
             if not elem.text or not elem.text.strip():
                 elem.text = i + "  "
             if not elem.tail or not elem.tail.strip():
                 elem.tail = i
             for elem in elem:
-                indent(elem, level+1)
+                indent(elem, level + 1)
             if not elem.tail or not elem.tail.strip():
                 elem.tail = i
         else:

--- a/examples/check_collada.py
+++ b/examples/check_collada.py
@@ -5,9 +5,9 @@ import traceback
 print('Attempting to load file %s' % sys.argv[1])
 
 try:
-    col = collada.Collada(sys.argv[1], \
-            ignore=[collada.DaeUnsupportedError, collada.DaeBrokenRefError])
-except:
+    col = collada.Collada(sys.argv[1],
+                          ignore=[collada.DaeUnsupportedError, collada.DaeBrokenRefError])
+except BaseException:
     traceback.print_exc()
     print()
     print("Failed to load collada file.")

--- a/examples/daeview/daeview.py
+++ b/examples/daeview/daeview.py
@@ -17,7 +17,7 @@ except pyglet.window.NoSuchConfigException:
     # Fall back to no multisampling for old hardware
     window = pyglet.window.Window(resizable=False)
 
-window.rotate_x  = 0.0
+window.rotate_x = 0.0
 window.rotate_y = 0.0
 window.rotate_z = 0.0
 
@@ -34,17 +34,18 @@ def on_mouse_drag(x, y, dx, dy, buttons, modifiers):
             window.rotate_y += 2
         else:
             window.rotate_y -= 2
-		
+
     if abs(dy) > 1:
         if dy > 0:
             window.rotate_x -= 2
         else:
             window.rotate_x += 2
 
-    
+
 @window.event
 def on_resize(width, height):
-    if height==0: height=1
+    if height == 0:
+        height = 1
     # Override the default on_resize handler to create a 3D projection
     glViewport(0, 0, width, height)
     glMatrixMode(GL_PROJECTION)
@@ -55,18 +56,19 @@ def on_resize(width, height):
 
 
 if __name__ == '__main__':
-    filename = sys.argv[1] if  len(sys.argv) > 1 else os.path.join(os.path.dirname(__file__), 'data', 'cockpit.zip')
+    filename = sys.argv[1] if len(sys.argv) > 1 else os.path.join(os.path.dirname(__file__), 'data', 'cockpit.zip')
 
     # open COLLADA file ignoring some errors in case they appear
-    collada_file = collada.Collada(filename, ignore=[collada.DaeUnsupportedError,
-                                            collada.DaeBrokenRefError])
+    collada_file = collada.Collada(filename, ignore=[
+        collada.common.DaeUnsupportedError,
+        collada.common.DaeBrokenRefError])
 
     daerender = renderer.GLSLRenderer(collada_file)
     #daerender = renderer.OldStyleRenderer(collada_file, window)
-	
+
     window.width = 1024
     window.height = 768
-    
+
     pyglet.app.run()
 
     daerender.cleanup()

--- a/examples/daeview/renderer/GLSLRenderer.py
+++ b/examples/daeview/renderer/GLSLRenderer.py
@@ -18,7 +18,7 @@ from .shader import Shader
 from . import shaders
 
 
-class GLSLRenderer: 
+class GLSLRenderer:
 
     def __init__(self, dae):
         self.dae = dae
@@ -30,10 +30,10 @@ class GLSLRenderer:
         self.batch_list = []
 
         # Initialize OpenGL
-        glClearColor(0.0, 0.0, 0.0, 0.5) # Black Background
-        glEnable(GL_DEPTH_TEST) # Enables Depth Testing
+        glClearColor(0.0, 0.0, 0.0, 0.5)  # Black Background
+        glEnable(GL_DEPTH_TEST)  # Enables Depth Testing
         glEnable(GL_CULL_FACE)
-        glEnable(GL_MULTISAMPLE);
+        glEnable(GL_MULTISAMPLE)
 
         glEnable(GL_BLEND)
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
@@ -77,8 +77,8 @@ class GLSLRenderer:
             for geom in self.dae.scene.objects('geometry'):
                 for prim in geom.primitives():
                     mat = prim.material
-                    diff_color = VecF(0.3,0.3,0.3,1.0)
-                    spec_color = None 
+                    diff_color = VecF(0.3, 0.3, 0.3, 1.0)
+                    spec_color = None
                     shininess = None
                     amb_color = None
                     tex_id = None
@@ -94,7 +94,7 @@ class GLSLRenderer:
                             # loading of the image using PIL if
                             # available. Unless it is already loaded.
                             img = colladaimage.pilimage
-                            if img: # can read and PIL available
+                            if img:  # can read and PIL available
                                 shader_prog = self.shaders['texture']
                                 # See if we already have texture for this image
                                 if colladaimage.id in self.textures:
@@ -125,7 +125,7 @@ class GLSLRenderer:
 
                                     self.textures[colladaimage.id] = tex_id
                             else:
-                                print('  %s = Texture %s: (not available)'%(
+                                print('  %s = Texture %s: (not available)' % (
                                     prop, colladaimage.id))
                         else:
                             if prop == 'diffuse' and value is not None:
@@ -151,7 +151,7 @@ class GLSLRenderer:
                         triangles.generateNormals()
                         # We will need flat lists for VBO (batch) initialization
                         vertices = triangles.vertex.flatten().tolist()
-                        batch_len = len(vertices)//3
+                        batch_len = len(vertices) // 3
                         indices = triangles.vertex_index.flatten().tolist()
                         normals = triangles.normal.flatten().tolist()
 
@@ -180,7 +180,7 @@ class GLSLRenderer:
                             # to work. Feel free to improve the way
                             # texture coordinates (uv) are collected
                             # for batch.add_indexed() invocation.
-                            uv = [[0.0,0.0]] * batch_len
+                            uv = [[0.0, 0.0]] * batch_len
                             for t in triangles:
                                 nidx = 0
                                 texcoords = t.texcoords[0]
@@ -191,7 +191,7 @@ class GLSLRenderer:
                             uv = [item for sublist in uv for item in sublist]
 
                             # Create textured batch
-                            batch.add_indexed(batch_len, 
+                            batch.add_indexed(batch_len,
                                               GL_TRIANGLES,
                                               None,
                                               indices,
@@ -200,7 +200,7 @@ class GLSLRenderer:
                                               ('t2f/static', uv))
                         else:
                             # Create colored batch
-                            batch.add_indexed(batch_len, 
+                            batch.add_indexed(batch_len,
                                               GL_TRIANGLES,
                                               None,
                                               indices,
@@ -210,7 +210,7 @@ class GLSLRenderer:
                         # Append the batch with supplementary
                         # information to the batch list
                         self.batch_list.append(
-                            (batch, shader_prog, tex_id, diff_color, 
+                            (batch, shader_prog, tex_id, diff_color,
                              spec_color, amb_color, shininess))
         print('done. Ready to render.')
 
@@ -223,7 +223,7 @@ class GLSLRenderer:
         z_offset = self.z_min - (self.z_max - self.z_min) * 3
         light_pos = VecF(100.0, 100.0, 10.0 * -z_offset)
         glLightfv(GL_LIGHT0, GL_POSITION, light_pos)
-        
+
         # Move the object deeper to the screen and rotate
         glTranslatef(0, 0, z_offset)
         glRotatef(rotate_x, 1.0, 0.0, 0.0)
@@ -261,7 +261,6 @@ class GLSLRenderer:
             batch.draw()
         if prev_shader_prog is not None:
             prev_shader_prog.unbind()
-
 
     def cleanup(self):
         print('Renderer cleaning up')

--- a/examples/daeview/renderer/OldStyleRenderer.py
+++ b/examples/daeview/renderer/OldStyleRenderer.py
@@ -11,7 +11,7 @@ import ctypes
 from . import glutils
 
 
-class OldStyleRenderer: 
+class OldStyleRenderer:
 
     def __init__(self, dae, window):
         self.dae = dae
@@ -21,20 +21,20 @@ class OldStyleRenderer:
         self.z_min = 100000.0
         self.textures = {}
 
-        glShadeModel(GL_SMOOTH) # Enable Smooth Shading
-        glClearColor(0.0, 0.0, 0.0, 0.5) # Black Background
-        glClearDepth(1.0) # Depth Buffer Setup
-        glEnable(GL_DEPTH_TEST) # Enables Depth Testing
-        glDepthFunc(GL_LEQUAL) # The Type Of Depth Testing To Do
-        
-        glEnable(GL_MULTISAMPLE);
+        glShadeModel(GL_SMOOTH)  # Enable Smooth Shading
+        glClearColor(0.0, 0.0, 0.0, 0.5)  # Black Background
+        glClearDepth(1.0)  # Depth Buffer Setup
+        glEnable(GL_DEPTH_TEST)  # Enables Depth Testing
+        glDepthFunc(GL_LEQUAL)  # The Type Of Depth Testing To Do
+
+        glEnable(GL_MULTISAMPLE)
 
         glEnable(GL_LIGHTING)
         glEnable(GL_LIGHT0)
         glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST)
         glCullFace(GL_BACK)
 
-        glEnable(GL_TEXTURE_2D) # Enable Texture Mapping
+        glEnable(GL_TEXTURE_2D)  # Enable Texture Mapping
         # glEnable(GL_TEXTURE_RECTANGLE_ARB) # Enable Texture Mapping
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
@@ -51,13 +51,13 @@ class OldStyleRenderer:
 
     def drawPrimitives(self):
         glBegin(GL_TRIANGLES)
-        
+
         if self.dae.scene is not None:
             for geom in self.dae.scene.objects('geometry'):
                 for prim in geom.primitives():
                     mat = prim.material
-                    diff_color = (GLfloat * 4)(*(0.3,0.3,0.3,0.0))
-                    spec_color = None 
+                    diff_color = (GLfloat * 4)(*(0.3, 0.3, 0.3, 0.0))
+                    spec_color = None
                     shininess = None
                     amb_color = None
                     tex_id = None
@@ -71,7 +71,7 @@ class OldStyleRenderer:
                             # loading of the image using PIL if
                             # available. Unless it is already loaded.
                             img = colladaimage.pilimage
-                            if img: # can read and PIL available
+                            if img:  # can read and PIL available
                                 # See if we already have texture for this image
                                 if colladaimage.id in self.textures:
                                     tex_id = self.textures[colladaimage.id]
@@ -102,7 +102,7 @@ class OldStyleRenderer:
 
                                     self.textures[colladaimage.id] = tex_id
                             else:
-                                print('  %s = Texture %s: (not available)'%(
+                                print('  %s = Texture %s: (not available)' % (
                                     prop, colladaimage.id))
                         else:
                             if prop == 'diffuse' and value is not None:
@@ -128,7 +128,6 @@ class OldStyleRenderer:
                         glBindTexture(GL_TEXTURE_2D, tex_id)
                     else:
                         glBindTexture(GL_TEXTURE_2D, 0)
-
 
                     # add triangles to the display list
                     for t in triangles:
@@ -166,16 +165,15 @@ class OldStyleRenderer:
         glutils.getGLError()
         glEnd()
 
-
     def render(self, rotate_x, rotate_y, rotate_z):
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
-        glMatrixMode(GL_PROJECTION) # Select The Projection Matrix
-        glLoadIdentity() # Reset The Projection Matrix
-        if self.window.height == 0: # Calculate The Aspect Ratio Of The Window
+        glMatrixMode(GL_PROJECTION)  # Select The Projection Matrix
+        glLoadIdentity()  # Reset The Projection Matrix
+        if self.window.height == 0:  # Calculate The Aspect Ratio Of The Window
             gluPerspective(100, self.window.width, 1.0, 5000.0)
         else:
             gluPerspective(100, self.window.width / self.window.height, 1.0, 5000.0)
-        glMatrixMode(GL_MODELVIEW) # Select The Model View Matrix
+        glMatrixMode(GL_MODELVIEW)  # Select The Model View Matrix
         glLoadIdentity()
         z_offset = self.z_min - (self.z_max - self.z_min) * 3
         light_pos = (GLfloat * 3)(100.0, 100.0, 100.0 * -z_offset)
@@ -184,10 +182,9 @@ class OldStyleRenderer:
         glRotatef(rotate_x, 1.0, 0.0, 0.0)
         glRotatef(rotate_y, 0.0, 1.0, 0.0)
         glRotatef(rotate_z, 0.0, 0.0, 1.0)
-        
+
         # draw the display list
         glCallList(self.displist)
-
 
     def cleanup(self):
         print('Renderer cleaning up')

--- a/examples/daeview/renderer/__init__.py
+++ b/examples/daeview/renderer/__init__.py
@@ -3,4 +3,3 @@ import sys
 
 from .GLSLRenderer import GLSLRenderer
 from .OldStyleRenderer import OldStyleRenderer
-

--- a/examples/daeview/renderer/glutils.py
+++ b/examples/daeview/renderer/glutils.py
@@ -10,10 +10,12 @@ def VecF(*args):
     """Simple function to create ctypes arrays of floats"""
     return (GLfloat * len(args))(*args)
 
+
 def getOpenGLVersion():
     """Get the OpenGL minor and major version number"""
     versionString = glGetString(GL_VERSION)
     return ctypes.cast(versionString, ctypes.c_char_p).value
+
 
 def getGLError():
     e = glGetError()

--- a/examples/daeview/renderer/shader.py
+++ b/examples/daeview/renderer/shader.py
@@ -8,132 +8,133 @@
 from pyglet.gl import *
 import ctypes
 
+
 def _as_bytes(s):
-	if isinstance(s, bytes):
-		return s
-	return s.encode('utf-8')
+    if isinstance(s, bytes):
+        return s
+    return s.encode('utf-8')
+
 
 class Shader:
-	# vert, frag and geom take arrays of source strings
-	# the arrays will be concatenated into one string by OpenGL
-	def __init__(self, vert = [], frag = [], geom = []):
-		# create the program handle
-		self.handle = glCreateProgram()
-		# we are not linked yet
-		self.linked = False
+    # vert, frag and geom take arrays of source strings
+    # the arrays will be concatenated into one string by OpenGL
+    def __init__(self, vert=[], frag=[], geom=[]):
+        # create the program handle
+        self.handle = glCreateProgram()
+        # we are not linked yet
+        self.linked = False
 
-		# create the vertex shader
-		self.createShader(vert, GL_VERTEX_SHADER)
-		# create the fragment shader
-		self.createShader(frag, GL_FRAGMENT_SHADER)
-		# the geometry shader will be the same, once pyglet supports the extension
-		# self.createShader(frag, GL_GEOMETRY_SHADER_EXT)
+        # create the vertex shader
+        self.createShader(vert, GL_VERTEX_SHADER)
+        # create the fragment shader
+        self.createShader(frag, GL_FRAGMENT_SHADER)
+        # the geometry shader will be the same, once pyglet supports the extension
+        # self.createShader(frag, GL_GEOMETRY_SHADER_EXT)
 
-		# attempt to link the program
-		self.link()
+        # attempt to link the program
+        self.link()
 
-	def createShader(self, strings, type):
-		count = len(strings)
-		# if we have no source code, ignore this shader
-		if count < 1:
-			return
+    def createShader(self, strings, type):
+        count = len(strings)
+        # if we have no source code, ignore this shader
+        if count < 1:
+            return
 
-		# create the shader handle
-		shader = glCreateShader(type)
+        # create the shader handle
+        shader = glCreateShader(type)
 
-		# convert the source strings into a ctypes pointer-to-char array, and upload them
-		# this is deep, dark, dangerous black magick - don't try stuff like this at home!
-		strings = [_as_bytes(s) for s in strings]
-		src = (ctypes.c_char_p * count)(*strings)
-		glShaderSource(shader, count, ctypes.cast(ctypes.pointer(src),
-			       ctypes.POINTER(ctypes.POINTER(ctypes.c_char))), None)
+        # convert the source strings into a ctypes pointer-to-char array, and upload them
+        # this is deep, dark, dangerous black magick - don't try stuff like this at home!
+        strings = [_as_bytes(s) for s in strings]
+        src = (ctypes.c_char_p * count)(*strings)
+        glShaderSource(shader, count, ctypes.cast(ctypes.pointer(src),
+                       ctypes.POINTER(ctypes.POINTER(ctypes.c_char))), None)
 
-		# compile the shader
-		glCompileShader(shader)
+        # compile the shader
+        glCompileShader(shader)
 
-		temp = ctypes.c_int(0)
-		# retrieve the compile status
-		glGetShaderiv(shader, GL_COMPILE_STATUS, ctypes.byref(temp))
+        temp = ctypes.c_int(0)
+        # retrieve the compile status
+        glGetShaderiv(shader, GL_COMPILE_STATUS, ctypes.byref(temp))
 
-		# if compilation failed, print the log
-		if not temp:
-			# retrieve the log length
-			glGetShaderiv(shader, GL_INFO_LOG_LENGTH, ctypes.byref(temp))
-			# create a buffer for the log
-			buffer = ctypes.create_string_buffer(temp.value)
-			# retrieve the log text
-			glGetShaderInfoLog(shader, temp, None, buffer)
-			# print the log to the console
-			print(buffer.value)
-		else:
-			# all is well, so attach the shader to the program
-			glAttachShader(self.handle, shader);
+        # if compilation failed, print the log
+        if not temp:
+            # retrieve the log length
+            glGetShaderiv(shader, GL_INFO_LOG_LENGTH, ctypes.byref(temp))
+            # create a buffer for the log
+            buffer = ctypes.create_string_buffer(temp.value)
+            # retrieve the log text
+            glGetShaderInfoLog(shader, temp, None, buffer)
+            # print the log to the console
+            print(buffer.value)
+        else:
+            # all is well, so attach the shader to the program
+            glAttachShader(self.handle, shader)
 
-	def link(self):
-		# link the program
-		glLinkProgram(self.handle)
+    def link(self):
+        # link the program
+        glLinkProgram(self.handle)
 
-		temp = ctypes.c_int(0)
-		# retrieve the link status
-		glGetProgramiv(self.handle, GL_LINK_STATUS, ctypes.byref(temp))
+        temp = ctypes.c_int(0)
+        # retrieve the link status
+        glGetProgramiv(self.handle, GL_LINK_STATUS, ctypes.byref(temp))
 
-		# if linking failed, print the log
-		if not temp:
-			#	retrieve the log length
-			glGetProgramiv(self.handle, GL_INFO_LOG_LENGTH, ctypes.byref(temp))
-			# create a buffer for the log
-			buffer = create_string_buffer(temp.value)
-			# retrieve the log text
-			glGetProgramInfoLog(self.handle, temp, None, buffer)
-			# print the log to the console
-			print(buffer.value)
-		else:
-			# all is well, so we are linked
-			self.linked = True
+        # if linking failed, print the log
+        if not temp:
+            #	retrieve the log length
+            glGetProgramiv(self.handle, GL_INFO_LOG_LENGTH, ctypes.byref(temp))
+            # create a buffer for the log
+            buffer = create_string_buffer(temp.value)
+            # retrieve the log text
+            glGetProgramInfoLog(self.handle, temp, None, buffer)
+            # print the log to the console
+            print(buffer.value)
+        else:
+            # all is well, so we are linked
+            self.linked = True
 
-	def bind(self):
-		# bind the program
-		glUseProgram(self.handle)
+    def bind(self):
+        # bind the program
+        glUseProgram(self.handle)
 
-	def unbind(self):
-		# unbind whatever program is currently bound - not necessarily this program,
-		# so this should probably be a class method instead
-		glUseProgram(0)
+    def unbind(self):
+        # unbind whatever program is currently bound - not necessarily this program,
+        # so this should probably be a class method instead
+        glUseProgram(0)
 
-	# upload a floating point uniform
-	# this program must be currently bound
-	def uniformf(self, name, *vals):
-		name = _as_bytes(name)
-		# check there are 1-4 values
-		if len(vals) in range(1, 5):
-			# select the correct function
-			{ 1 : glUniform1f,
-				2 : glUniform2f,
-				3 : glUniform3f,
-				4 : glUniform4f
-				# retrieve the uniform location, and set
-			}[len(vals)](glGetUniformLocation(self.handle, name), *vals)
+    # upload a floating point uniform
+    # this program must be currently bound
+    def uniformf(self, name, *vals):
+        name = _as_bytes(name)
+        # check there are 1-4 values
+        if len(vals) in range(1, 5):
+            # select the correct function
+            {1: glUniform1f,
+             2: glUniform2f,
+             3: glUniform3f,
+             4: glUniform4f
+             # retrieve the uniform location, and set
+             }[len(vals)](glGetUniformLocation(self.handle, name), *vals)
 
-	# upload an integer uniform
-	# this program must be currently bound
-	def uniformi(self, name, *vals):
-		name = _as_bytes(name)
-		# check there are 1-4 values
-		if len(vals) in range(1, 5):
-			# select the correct function
-			{ 1 : glUniform1i,
-				2 : glUniform2i,
-				3 : glUniform3i,
-				4 : glUniform4i
-				# retrieve the uniform location, and set
-			}[len(vals)](glGetUniformLocation(self.handle, name), *vals)
+    # upload an integer uniform
+    # this program must be currently bound
+    def uniformi(self, name, *vals):
+        name = _as_bytes(name)
+        # check there are 1-4 values
+        if len(vals) in range(1, 5):
+            # select the correct function
+            {1: glUniform1i,
+             2: glUniform2i,
+             3: glUniform3i,
+             4: glUniform4i
+             # retrieve the uniform location, and set
+             }[len(vals)](glGetUniformLocation(self.handle, name), *vals)
 
-	# upload a uniform matrix
-	# works with matrices stored as lists,
-	# as well as euclid matrices
-	def uniform_matrixf(self, name, mat):
-		# obtain the uniform location
-		loc = glGetUniformLocation(self.Handle, name)
-		# upload the 4x4 floating point matrix
-		glUniformMatrix4fv(loc, 1, False, (c_float * 16)(*mat))
-
+    # upload a uniform matrix
+    # works with matrices stored as lists,
+    # as well as euclid matrices
+    def uniform_matrixf(self, name, mat):
+        # obtain the uniform location
+        loc = glGetUniformLocation(self.Handle, name)
+        # upload the 4x4 floating point matrix
+        glUniformMatrix4fv(loc, 1, False, (c_float * 16)(*mat))

--- a/examples/daeview/renderer/shaders.py
+++ b/examples/daeview/renderer/shaders.py
@@ -1,18 +1,18 @@
 ######################################################################
 # Flat Shader
-# This shader applies the given model view matrix to the vertices, 
+# This shader applies the given model view matrix to the vertices,
 # and uses a uniform color value.
 flatShader = (['''
 uniform mat4 mvpMatrix;
 attribute vec4 vVertex;
 void main(void)
 {
-  gl_Position = mvpMatrix * vVertex; 
+  gl_Position = mvpMatrix * vVertex;
 }'''],
-['''
+              ['''
 //precision mediump float;
 uniform vec4 vColor;
-void main(void) 
+void main(void)
 {
   gl_FragColor = vColor;
 }'''])
@@ -39,18 +39,18 @@ void main(void)
   ecPosition = mvMatrix * vVertex;
   ecPosition3 = ecPosition.xyz /ecPosition.w;
   vec3 vLightDir = normalize(vLightPos - ecPosition3);
-  float fDot = max(0.0, dot(vNorm, vLightDir)); 
+  float fDot = max(0.0, dot(vNorm, vLightDir));
   vFragColor.rgb = vColor.rgb * fDot;
   vFragColor.a = vColor.a;
 //  vFragColor = vColor;
   mat4 mvpMatrix;
   mvpMatrix = pMatrix * mvMatrix;
-  gl_Position = mvpMatrix * vVertex; 
+  gl_Position = mvpMatrix * vVertex;
 }'''],
-['''
+                  ['''
 //precision mediump float;
-varying vec4 vFragColor; 
-void main(void) 
+varying vec4 vFragColor;
+void main(void)
 {
   gl_FragColor = vFragColor;
 }'''])
@@ -93,7 +93,7 @@ void main(void)
   vec4 attenuatedLight = lightColor * attenuation;
 //  float attenuation = 1.0f;
 // Dot product gives us diffuse intensity
-  float diff = max(0.0, dot(vEyeNormal, vLightDir)); 
+  float diff = max(0.0, dot(vEyeNormal, vLightDir));
 // Multiply intensity by diffuse color, force alpha to 1.0
   vVaryingColor = attenuatedLight * diffuseColor * diff;
 // Add in ambient light
@@ -107,12 +107,12 @@ void main(void)
   }
 // Don't forget to transform the geometry
   mat4 mvpMatrix = pMatrix * mvMatrix;
-  gl_Position = mvpMatrix * vVertex; 
+  gl_Position = mvpMatrix * vVertex;
 }'''],
-['''
+              ['''
 //precision mediump float;
-varying vec4 vVaryingColor; 
-void main(void) 
+varying vec4 vVaryingColor;
+void main(void)
 {
   gl_FragColor = vVaryingColor;
 }'''])
@@ -133,8 +133,8 @@ void main()
   eyeVec = -vVertex;
   gl_Position = ftransform();
 }
-'''], 
-['''
+'''],
+               ['''
 uniform vec4 diffuse, specular, ambient;
 uniform float shininess;
 varying vec3 normal, lightDir0, eyeVec;
@@ -192,9 +192,9 @@ void main(void)
 
 // Don't forget to transform the geometry
   mat4 mvpMatrix = pMatrix * mvMatrix;
-  gl_Position = mvpMatrix * vVertex; 
+  gl_Position = mvpMatrix * vVertex;
 }'''],
-['''
+            ['''
 precision mediump float;
 uniform vec4 ambientColor;
 uniform vec4 diffuseColor;
@@ -208,7 +208,7 @@ varying vec3 vVaryingNormal;
 varying vec3 vVaryingLightDir;
 varying float distanceToLight;
 //varying float spotEffect;
-void main(void) 
+void main(void)
 {
 //  float attenuation = 1.0 / (fConstantAttenuation + fLinearAttenuation * distanceToLight + fQuadraticAttenuation * distanceToLight * distanceToLight);
   float attenuation = fConstantAttenuation / ((1.0 + fLinearAttenuation * distanceToLight) * (1.0 + fQuadraticAttenuation * distanceToLight * distanceToLight));
@@ -228,7 +228,7 @@ void main(void)
     float fSpec = pow(spec, shininess);
     gl_FragColor.rgb += attenuatedLight.rgb * vec3(fSpec, fSpec, fSpec);
   }
-// For some reaseons, without following multiplications, all scenes exported from Blender are dark. 
+// For some reaseons, without following multiplications, all scenes exported from Blender are dark.
 // Need to investigate the real reason. For now, it is just workaround to make scene brighter.
 //  gl_FragColor.rgb *= vec3(5.5, 5.5, 5.5);
 //  gl_FragColor.rgb *= vec3(2.5, 2.5, 2.5);
@@ -249,7 +249,7 @@ varying vec4 vFragColor;
 attribute vec2 vTexCoord0;
 varying vec2 vTex;
 void main(void)
-{ 
+{
  mat3 mNormalMatrix;
  mNormalMatrix[0] = normalize(mvMatrix[0].xyz);
  mNormalMatrix[1] = normalize(mvMatrix[1].xyz);
@@ -260,15 +260,15 @@ void main(void)
  ecPosition = mvMatrix * vVertex;
  ecPosition3 = ecPosition.xyz /ecPosition.w;
  vec3 vLightDir = normalize(vLightPos - ecPosition3);
- float fDot = max(0.0, dot(vNorm, vLightDir)); 
+ float fDot = max(0.0, dot(vNorm, vLightDir));
  vFragColor.rgb = vColor.rgb * fDot;
  vFragColor.a = vColor.a;
  vTex = vTexCoord0;
  mat4 mvpMatrix;
  mvpMatrix = pMatrix * mvMatrix;
- gl_Position = mvpMatrix * vVertex; 
+ gl_Position = mvpMatrix * vVertex;
 }'''],
-['''
+                         ['''
 precision mediump float;
 varying vec4 vFragColor;
 varying vec2 vTex;
@@ -311,8 +311,8 @@ void main()
 	gl_Position = ftransform();
         gl_TexCoord[0]  = gl_TextureMatrix[0] * gl_MultiTexCoord0;
 }
-'''], 
-['''
+'''],
+                ['''
 varying vec3 normal, lightDir0, eyeVec;
 uniform sampler2D my_color_texture[1]; //0 = ColorMap
 
@@ -323,7 +323,7 @@ void main (void)
 
 /*	final_color = (gl_FrontLightModelProduct.sceneColor * vec4(texColor.rgb,1.0)) +
 		      gl_LightSource[0].ambient * vec4(texColor.rgb,1.0);*/
-	final_color = (gl_FrontLightModelProduct.sceneColor * vec4(texColor.rgb,1.0)) + 
+	final_color = (gl_FrontLightModelProduct.sceneColor * vec4(texColor.rgb,1.0)) +
 		       vec4(texColor.rgb,1.0);
 
 	vec3 N = normalize(normal);

--- a/examples/print_collada_info.py
+++ b/examples/print_collada_info.py
@@ -3,6 +3,7 @@
 import collada
 import sys
 
+
 def inspectController(controller):
     """Display contents of a controller object found in the scene."""
     print('    Controller (id=%s) (type=%s)' % (controller.skin.id, type(controller).__name__))
@@ -10,21 +11,24 @@ def inspectController(controller):
     for controlled_prim in controller.primitives():
         print('       Primitive', type(controlled_prim.primitive).__name__)
 
+
 def inspectGeometry(obj):
     """Display contents of a geometry object found in the scene."""
     materials = set()
     for prim in obj.primitives():
-        materials.add( prim.material )
+        materials.add(prim.material)
 
-    print('    Geometry (id=%s): %d primitives'%(obj.original.id, len(obj)))
+    print('    Geometry (id=%s): %d primitives' % (obj.original.id, len(obj)))
     for prim in obj.primitives():
         print('        Primitive (type=%s): len=%d vertices=%d' % (type(prim).__name__, len(prim), len(prim.vertex)))
     for mat in materials:
-        if mat: inspectMaterial( mat )
+        if mat:
+            inspectMaterial(mat)
+
 
 def inspectMaterial(mat):
     """Display material contents."""
-    print('        Material %s: shading %s'%(mat.effect.id, mat.effect.shadingtype))
+    print('        Material %s: shading %s' % (mat.effect.id, mat.effect.shadingtype))
     for prop in mat.effect.supported:
         value = getattr(mat.effect, prop)
         # it can be a float, a color (tuple) or a Map ( a texture )
@@ -33,14 +37,15 @@ def inspectMaterial(mat):
             # Accessing this attribute forces the loading of the image
             # using PIL if available. Unless it is already loaded.
             img = colladaimage.pilimage
-            if img: # can read and PIL available
-                print('            %s = Texture %s:'%(prop, colladaimage.id),\
+            if img:  # can read and PIL available
+                print('            %s = Texture %s:' % (prop, colladaimage.id),
                       img.format, img.mode, img.size)
             else:
-                print('            %s = Texture %s: (not available)'%(
-                                   prop, colladaimage.id))
+                print('            %s = Texture %s: (not available)' % (
+                    prop, colladaimage.id))
         else:
-            print('            %s ='%(prop), value)
+            print('            %s =' % (prop), value)
+
 
 def inspectCollada(col):
     # Display the file contents
@@ -48,31 +53,32 @@ def inspectCollada(col):
     print('  Geometry:')
     if col.scene is not None:
         for geom in col.scene.objects('geometry'):
-            inspectGeometry( geom )
+            inspectGeometry(geom)
     print('  Controllers:')
     if col.scene is not None:
         for controller in col.scene.objects('controller'):
-            inspectController( controller )
+            inspectController(controller)
     print('  Cameras:')
     if col.scene is not None:
         for cam in col.scene.objects('camera'):
-            print('    Camera %s: '%cam.original.id)
+            print('    Camera %s: ' % cam.original.id)
     print('  Lights:')
     if col.scene is not None:
         for light in col.scene.objects('light'):
             print('    Light %s: color =' % light.original.id, light.color)
 
-    if not col.errors: print('File read without errors')
+    if not col.errors:
+        print('File read without errors')
     else:
         print('Errors:')
         for error in col.errors:
             print(' ', error)
 
+
 if __name__ == '__main__':
-    filename = sys.argv[1] if  len(sys.argv) > 1 else 'misc/base.zip'
+    filename = sys.argv[1] if len(sys.argv) > 1 else 'misc/base.zip'
 
     # open COLLADA file ignoring some errors in case they appear
     col = collada.Collada(filename, ignore=[collada.DaeUnsupportedError,
                                             collada.DaeBrokenRefError])
     inspectCollada(col)
-    

--- a/examples/recurse_check.py
+++ b/examples/recurse_check.py
@@ -1,14 +1,16 @@
 import sys
-import os, os.path
+import os
+import os.path
 import traceback
 import time
 import argparse
 
 try:
     import collada
-except:
+except BaseException:
     sys.exit("Could not find pycollada library.")
-        
+
+
 def main():
 
     parser = argparse.ArgumentParser(
@@ -24,18 +26,18 @@ def main():
                         help='Print a summary at the end of how many files had warnings and errors')
     parser.add_argument('--zip', '-z', default=False, action='store_true',
                         help='Include .zip files when searching for files to load')
-    
+
     args = parser.parse_args()
-    
+
     if not os.path.isdir(args.directory):
         sys.exit("Given path '%s' is not a directory." % args.directory)
-    
+
     directories = [args.directory]
     collada_files = []
     while len(directories) > 0:
         directory = directories.pop()
         for name in os.listdir(directory):
-            fullpath = os.path.join(directory,name)
+            fullpath = os.path.join(directory, name)
             (root, ext) = os.path.splitext(fullpath)
             if os.path.isfile(fullpath) and ext.lower() == ".dae":
                 collada_files.append(fullpath)
@@ -43,24 +45,24 @@ def main():
                 collada_files.append(fullpath)
             elif os.path.isdir(fullpath):
                 directories.append(fullpath)
-    
+
     collada_files.sort()
-    
+
     file_success_count = 0
     file_warning_count = 0
     file_error_count = 0
-    
+
     for c in collada_files:
         (root, leaf) = os.path.split(c)
         print("'%s'..." % leaf,)
         sys.stdout.flush()
-     
+
         start_time = time.time()
-     
+
         try:
-            col = collada.Collada(c, \
-                ignore=[collada.DaeUnsupportedError, collada.DaeBrokenRefError])
-            
+            col = collada.Collada(c,
+                                  ignore=[collada.DaeUnsupportedError, collada.DaeBrokenRefError])
+
             if len(col.errors) > 0:
                 print("WARNINGS:", len(col.errors))
                 file_warning_count += 1
@@ -74,12 +76,12 @@ def main():
                                 print("   %s" % str(err))
                                 break
                         if ct > 1:
-                            print("   %s: %d additional warnings of this type" % (e, ct-1))
+                            print("   %s: %d additional warnings of this type" % (e, ct - 1))
             else:
                 print("SUCCESS")
                 file_success_count += 1
-                
-            #do some sanity checks looping through result
+
+            # do some sanity checks looping through result
             if not col.scene is None:
                 for geom in col.scene.objects('geometry'):
                     for prim in geom.primitives():
@@ -89,17 +91,17 @@ def main():
         except (KeyboardInterrupt, SystemExit):
             print()
             sys.exit("Keyboard interrupt. Exiting.")
-        except:
+        except BaseException:
             print("ERROR")
             file_error_count += 1
             if args.show_errors:
                 print()
                 traceback.print_exc()
                 print()
-            
+
         end_time = time.time()
         if args.show_time:
-            print("   Loaded in %.3f seconds" % (end_time-start_time))
+            print("   Loaded in %.3f seconds" % (end_time - start_time))
 
     if args.show_summary:
         print()
@@ -109,6 +111,7 @@ def main():
         print("Files loaded successfully: %d" % file_success_count)
         print("Files with warnings: %d" % file_warning_count)
         print("Files with errors: %d" % file_error_count)
-            
+
+
 if __name__ == "__main__":
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max_line_length = 170
+extend-ignore = NIC002,W504

--- a/setup.py
+++ b/setup.py
@@ -9,20 +9,20 @@ if sys.version_info[0] < 3:
         install_requires.append('unittest2')
 
 setup(
-    name = "pycollada",
-    version = "0.7.2",
-    description = "python library for reading and writing collada documents",
-    author = "Jeff Terrace and contributors",
-    author_email = 'jterrace@gmail.com',
+    name="pycollada",
+    version="0.7.2",
+    description="python library for reading and writing collada documents",
+    author="Jeff Terrace and contributors",
+    author_email='jterrace@gmail.com',
     platforms=["any"],
     license="BSD",
     install_requires=install_requires,
-    extras_require = {
+    extras_require={
         'prettyprint': ["lxml"],
         'validation': ["lxml"]
     },
-    url = "http://pycollada.readthedocs.org/",
-    test_suite = "collada.tests",
-    packages = find_packages(),
+    url="http://pycollada.readthedocs.org/",
+    test_suite="collada.tests",
+    packages=find_packages(),
     package_data={'collada': ['resources/*.xml']}
 )


### PR DESCRIPTION
Hey, I'm not usually a fan of large whitespace changes as they're hard to review, feel free to reject this out of hand I definitely don't mind haha. There should be no logic changes here, and if nothing else may be useful as a away to look into things that are suspicious.  

I ran an autoformatter and did some manual fixes to get `collada` to pass flake8. I ignored line length as it would all have to be done manually. It did remove a bunch of unused inputs which is nice. I also fixed `examples/daeviewer.py` but didn't do flake8 for the examples. This now passes:

```
flake8 collada
pytest .
```

I ran the following iteratively between manual fixes:
```
autoflake --recursive --in-place --imports=collada,numpy  --remove-unused-variables .
autopep8 --aggressive --aggressive --verbose --recursive --experimental --in-place .
```