### PR TITLE
Use README as project description

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.markdown

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from setuptools import find_packages, setup
 
@@ -8,12 +9,18 @@ if sys.version_info[0] < 3:
     if not hasattr(unittest.TestCase, "assertIsNone"):
         install_requires.append('unittest2')
 
+readme_path = os.path.join(os.path.split(__file__)[0], "README.markdown")
+with open(readme_path, "r") as f:
+    readme_text = f.read()
+
 setup(
     name="pycollada",
     version="0.8",
     description="python library for reading and writing collada documents",
     author="Jeff Terrace and contributors",
     author_email='jterrace@gmail.com',
+    long_description=readme_text,
+    long_description_content_type="text/markdown",
     platforms=["any"],
     license="BSD",
     install_requires=install_requires,
@@ -22,6 +29,7 @@ setup(
         'validation': ["lxml"]
     },
     url="http://pycollada.readthedocs.org/",
+    project_urls={"Source": "https://github.com/pycollada/pycollada"},
     test_suite="collada.tests",
     packages=find_packages(),
     package_data={'collada': ['resources/*.xml']}


### PR DESCRIPTION
This is the text displayed in the project page at https://pypi.org/project/pycollada/. Also add link to source in project page.

If you don't want the `MANIFEST.in` file, an alternative is to rename `README.markdown` to either `README` or `README.md` (see [setuptools docs](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html)).