### PR TITLE
Specify build backend in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "setuptools >= 42",
+]


### PR DESCRIPTION
Instead of relying on legacy assume-setuptools behaviour