### PR TITLE
Move project metadata to pyproject.toml

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -228,7 +228,7 @@ Releasing
 
    Add this to docs/changelog.rst.
 
-#. Update setup.py to change version to new version.
+#. Update pyproject.toml to change version to new version.
 
 #. Update ``collada/__init__.py`` to new version.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools >= 42",
+    "setuptools >= 61",
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,34 @@ build-backend = "setuptools.build_meta"
 requires = [
     "setuptools >= 42",
 ]
+
+[project]
+name = "pycollada"
+version = "0.8"
+description = "python library for reading and writing collada documents"
+authors = [
+    {name = "Jeff Terrace and contributors", email = "jterrace@gmail.com"},
+]
+license = {text = "BSD"}
+dependencies = [
+    "python-dateutil>=2.2",
+    "numpy",
+    'unittest2; python_version<"2.7"',
+]
+
+[project.optional-dependencies]
+prettyprint = ["lxml"]
+validation = ["lxml"]
+
+[project.urls]
+Homepage = "http://pycollada.readthedocs.org/"
+
+[tool.setuptools]
+platforms = ["any"]
+include-package-data = false
+
+[tool.setuptools.packages]
+find = {namespaces = false}
+
+[tool.setuptools.package-data]
+collada = ["resources/*.xml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "setuptools >= 42",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,5 @@
-import sys
-from setuptools import find_packages, setup
-
-install_requires = ['python-dateutil>=2.2', 'numpy']
-
-if sys.version_info[0] < 3:
-    import unittest
-    if not hasattr(unittest.TestCase, "assertIsNone"):
-        install_requires.append('unittest2')
+from setuptools import setup
 
 setup(
-    name="pycollada",
-    version="0.8",
-    description="python library for reading and writing collada documents",
-    author="Jeff Terrace and contributors",
-    author_email='jterrace@gmail.com',
-    platforms=["any"],
-    license="BSD",
-    install_requires=install_requires,
-    extras_require={
-        'prettyprint': ["lxml"],
-        'validation': ["lxml"]
-    },
-    url="http://pycollada.readthedocs.org/",
     test_suite="collada.tests",
-    packages=find_packages(),
-    package_data={'collada': ['resources/*.xml']}
 )


### PR DESCRIPTION
Makes metadata more declarative and reliable for static inspection services (eg dependabot). Requires Python 3.7 or later