### PR TITLE
Drop deprecated pkg_resources

### DIFF
--- a/collada/resources/__init__.py
+++ b/collada/resources/__init__.py
@@ -1,0 +1,26 @@
+import sys
+
+
+def resource_string(file_name: str) -> str:
+    """
+    Get the value of a file in `collada/resources/{file_name}`
+    as a string.
+
+    Parameters
+    -----------
+    file_name
+      The name of the file in `collada/resources/{file_name}`
+
+    Returns
+    ----------
+    value
+      The contents of the file.
+    """
+    if sys.version_info <= (3, 9):
+        from importlib.resources import read_text
+
+        return read_text("collada.resources", file_name)
+    else:
+        from importlib import resources
+
+        return resources.files("collada").joinpath("resources", file_name).read_text()

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -14,16 +14,13 @@
 """This module contains helper classes and functions for working
 with the COLLADA 1.4.1 schema."""
 
-import os
 import lxml
 import lxml.etree
+from importlib import resources
 from collada.util import bytes, BytesIO
 
-# the absolute directory of this file
-_cwd = os.path.abspath(os.path.expanduser(os.path.dirname(__file__)))
 
-
-def resource_string(file_name: str) -> str:
+def _resource_string(file_name: str) -> str:
     """
     Get the value of a file in `collada/resources/{file_name}`
     as a string.
@@ -35,17 +32,16 @@ def resource_string(file_name: str) -> str:
 
     Returns
     ----------
-    value
+       value
       The contents of the file.
     """
-    with open(os.path.join(_cwd, "resources", file_name)) as f:
-        return f.read()
+    return resources.files("collada").joinpath("resources", file_name).read_text()
 
 
 # get a copy of the XML schema
 # resource_string returns bytes so decode into string
-COLLADA_SCHEMA_1_4_1 = resource_string('schema-1.4.1.xml')
-XML_XSD = resource_string('xsd.xml')
+COLLADA_SCHEMA_1_4_1 = _resource_string('schema-1.4.1.xml')
+XML_XSD = _resource_string('xsd.xml')
 
 
 class ColladaResolver(lxml.etree.Resolver):

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -36,11 +36,9 @@ def resource_string(file_name: str) -> str:
       The contents of the file.
     """
     if sys.version_info <= (3, 9):
-        from pkg_resources import resource_string
+        from importlib.resources import read_text
 
-        return resource_string("collada", "resources/{}".format(file_name)).decode(
-            "utf-8"
-        )
+        return read_text("collada", "resources/{}".format(file_name))
     else:
         from importlib import resources
 

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -14,13 +14,13 @@
 """This module contains helper classes and functions for working
 with the COLLADA 1.4.1 schema."""
 
+import sys
 import lxml
 import lxml.etree
-from importlib import resources
 from collada.util import bytes, BytesIO
 
 
-def _resource_string(file_name: str) -> str:
+def resource_string(file_name: str) -> str:
     """
     Get the value of a file in `collada/resources/{file_name}`
     as a string.
@@ -32,16 +32,24 @@ def _resource_string(file_name: str) -> str:
 
     Returns
     ----------
-       value
+    value
       The contents of the file.
     """
-    return resources.files("collada").joinpath("resources", file_name).read_text()
+    if sys.version_info <= (3, 8):
+        from pkg_resources import resource_string
+
+        return resource_string("collada", "resources/{}".format(file_name)).decode(
+            "utf-8"
+        )
+    else:
+        from importlib import resources
+
+        return resources.files("collada").joinpath("resources", file_name).read_text()
 
 
 # get a copy of the XML schema
-# resource_string returns bytes so decode into string
-COLLADA_SCHEMA_1_4_1 = _resource_string('schema-1.4.1.xml')
-XML_XSD = _resource_string('xsd.xml')
+COLLADA_SCHEMA_1_4_1 = resource_string("schema-1.4.1.xml")
+XML_XSD = resource_string("xsd.xml")
 
 
 class ColladaResolver(lxml.etree.Resolver):

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -14,22 +14,36 @@
 """This module contains helper classes and functions for working
 with the COLLADA 1.4.1 schema."""
 
+import os
 import lxml
 import lxml.etree
 from collada.util import bytes, BytesIO
 
-from pkg_resources import resource_string
+# the absolute directory of this file
+_cwd = os.path.abspath(os.path.expanduser(os.path.dirname(__file__)))
+
+def resource_string(file_name: str) -> str:
+    """
+    Get the value of a file in `collada/resources/{file_name}`
+    as a string.
+
+    Parameters
+    -----------
+    file_name
+      The name of the file in `collada/resources/{file_name}`
+
+    Returns
+    ----------
+    value
+      The contents of the file.
+    """
+    with open(os.path.join(_cwd, "resources", file_name)) as f:
+        return f.read()
 
 # get a copy of the XML schema
 # resource_string returns bytes so decode into string
-COLLADA_SCHEMA_1_4_1 = str(resource_string(
-    'collada',
-    'resources/schema-1.4.1.xml').decode('utf-8'))
-
-XML_XSD = str(resource_string(
-    'collada',
-    'resources/xsd.xml').decode('utf-8'))
-
+COLLADA_SCHEMA_1_4_1 = resource_string('schema-1.4.1.xml')
+XML_XSD = resource_string('xsd.xml')
 
 class ColladaResolver(lxml.etree.Resolver):
     """COLLADA XML Resolver. If a known URL referenced

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -14,36 +14,11 @@
 """This module contains helper classes and functions for working
 with the COLLADA 1.4.1 schema."""
 
-import sys
 import lxml
 import lxml.etree
 from collada.util import bytes, BytesIO
 
-
-def resource_string(file_name: str) -> str:
-    """
-    Get the value of a file in `collada/resources/{file_name}`
-    as a string.
-
-    Parameters
-    -----------
-    file_name
-      The name of the file in `collada/resources/{file_name}`
-
-    Returns
-    ----------
-    value
-      The contents of the file.
-    """
-    if sys.version_info <= (3, 9):
-        from importlib.resources import read_text
-
-        return read_text("collada.resources", file_name)
-    else:
-        from importlib import resources
-
-        return resources.files("collada").joinpath("resources", file_name).read_text()
-
+from .resources import resource_string
 
 # get a copy of the XML schema
 COLLADA_SCHEMA_1_4_1 = resource_string("schema-1.4.1.xml")

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -38,7 +38,7 @@ def resource_string(file_name: str) -> str:
     if sys.version_info <= (3, 9):
         from importlib.resources import read_text
 
-        return read_text("collada", "resources/{}".format(file_name))
+        return read_text("collada.resources", file_name)
     else:
         from importlib import resources
 

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -35,7 +35,7 @@ def resource_string(file_name: str) -> str:
     value
       The contents of the file.
     """
-    if sys.version_info <= (3, 8):
+    if sys.version_info <= (3, 9):
         from pkg_resources import resource_string
 
         return resource_string("collada", "resources/{}".format(file_name)).decode(

--- a/collada/schema.py
+++ b/collada/schema.py
@@ -22,6 +22,7 @@ from collada.util import bytes, BytesIO
 # the absolute directory of this file
 _cwd = os.path.abspath(os.path.expanduser(os.path.dirname(__file__)))
 
+
 def resource_string(file_name: str) -> str:
     """
     Get the value of a file in `collada/resources/{file_name}`
@@ -40,10 +41,12 @@ def resource_string(file_name: str) -> str:
     with open(os.path.join(_cwd, "resources", file_name)) as f:
         return f.read()
 
+
 # get a copy of the XML schema
 # resource_string returns bytes so decode into string
 COLLADA_SCHEMA_1_4_1 = resource_string('schema-1.4.1.xml')
 XML_XSD = resource_string('xsd.xml')
+
 
 class ColladaResolver(lxml.etree.Resolver):
     """COLLADA XML Resolver. If a known URL referenced


### PR DESCRIPTION
Hey, here's a fix for `pkg_resources` being deprecated. It's possible to do this with `importlib` on Python 3.8+ but I thought it was simpler to just use the standard library. 