### PR TITLE
Speeding up DAE loading by ~20%

### DIFF
--- a/collada/__init__.py
+++ b/collada/__init__.py
@@ -222,9 +222,6 @@ class Collada(object):
             # failed to extract a namespace, using default
             traceback.print_exc()
 
-        # Pre-cache commonly used tags and XPath patterns for better performance
-        self._precache_tags()
-
         # functions which will load various things into collada object
         self._loadAssetInfo()
         self._loadImages()
@@ -241,45 +238,6 @@ class Collada(object):
 
     def _setIndexedList(self, propname, data):
         setattr(self, propname, IndexedList(data, ('id',)))
-
-    def _precache_tags(self):
-        """Pre-cache commonly used tags and XPath patterns for better performance."""
-        t = self.tag
-        # Pre-cache individual tags
-        self._tags = {
-            'float_array': t('float_array'),
-            'IDREF_array': t('IDREF_array'),
-            'Name_array': t('Name_array'),
-            'technique_common': t('technique_common'),
-            'accessor': t('accessor'),
-            'param': t('param'),
-            'mesh': t('mesh'),
-            'source': t('source'),
-            'vertices': t('vertices'),
-            'input': t('input'),
-            'extra': t('extra'),
-            'double_sided': t('double_sided'),
-            'polylist': t('polylist'),
-            'triangles': t('triangles'),
-            'tristrips': t('tristrips'),
-            'trifans': t('trifans'),
-            'lines': t('lines'),
-            'polygons': t('polygons'),
-            'p': t('p'),
-            'vcount': t('vcount'),
-            'bind_material': t('bind_material'),
-            'instance_material': t('instance_material'),
-            'bind_vertex_input': t('bind_vertex_input'),
-            'node': t('node'),
-        }
-        # Pre-cache common XPath patterns
-        tc = self._tags['technique_common']
-        acc = self._tags['accessor']
-        param = self._tags['param']
-        self._xpath_accessor_params = '%s/%s/%s' % (tc, acc, param)
-        bm = self._tags['bind_material']
-        im = self._tags['instance_material']
-        self._xpath_materials = '%s/%s/%s' % (bm, tc, im)
 
     def handleError(self, error):
         self.errors.append(error)

--- a/collada/__init__.py
+++ b/collada/__init__.py
@@ -222,6 +222,9 @@ class Collada(object):
             # failed to extract a namespace, using default
             traceback.print_exc()
 
+        # Pre-cache commonly used tags and XPath patterns for better performance
+        self._precache_tags()
+
         # functions which will load various things into collada object
         self._loadAssetInfo()
         self._loadImages()
@@ -238,6 +241,45 @@ class Collada(object):
 
     def _setIndexedList(self, propname, data):
         setattr(self, propname, IndexedList(data, ('id',)))
+
+    def _precache_tags(self):
+        """Pre-cache commonly used tags and XPath patterns for better performance."""
+        t = self.tag
+        # Pre-cache individual tags
+        self._tags = {
+            'float_array': t('float_array'),
+            'IDREF_array': t('IDREF_array'),
+            'Name_array': t('Name_array'),
+            'technique_common': t('technique_common'),
+            'accessor': t('accessor'),
+            'param': t('param'),
+            'mesh': t('mesh'),
+            'source': t('source'),
+            'vertices': t('vertices'),
+            'input': t('input'),
+            'extra': t('extra'),
+            'double_sided': t('double_sided'),
+            'polylist': t('polylist'),
+            'triangles': t('triangles'),
+            'tristrips': t('tristrips'),
+            'trifans': t('trifans'),
+            'lines': t('lines'),
+            'polygons': t('polygons'),
+            'p': t('p'),
+            'vcount': t('vcount'),
+            'bind_material': t('bind_material'),
+            'instance_material': t('instance_material'),
+            'bind_vertex_input': t('bind_vertex_input'),
+            'node': t('node'),
+        }
+        # Pre-cache common XPath patterns
+        tc = self._tags['technique_common']
+        acc = self._tags['accessor']
+        param = self._tags['param']
+        self._xpath_accessor_params = '%s/%s/%s' % (tc, acc, param)
+        bm = self._tags['bind_material']
+        im = self._tags['instance_material']
+        self._xpath_materials = '%s/%s/%s' % (bm, tc, im)
 
     def handleError(self, error):
         self.errors.append(error)

--- a/collada/common.py
+++ b/collada/common.py
@@ -2,6 +2,9 @@ from collada.xmlutil import etree, ElementMaker, COLLADA_NS
 
 E = ElementMaker(namespace=COLLADA_NS, nsmap={None: COLLADA_NS})
 
+# Cache for tag strings - key is (namespace, text), value is the qualified tag string
+_tag_cache = {}
+
 
 def tag(text, namespace=None):
     """
@@ -16,7 +19,15 @@ def tag(text, namespace=None):
     """
     if namespace is None:
         namespace = COLLADA_NS
-    return str(etree.QName(namespace, text))
+    
+    cache_key = (namespace, text)
+    cached = _tag_cache.get(cache_key)
+    if cached is not None:
+        return cached
+    
+    result = '{%s}%s' % (namespace, text)
+    _tag_cache[cache_key] = result
+    return result
 
 
 def tagger(namespace=None):
@@ -30,8 +41,17 @@ def tagger(namespace=None):
     :return:
       tag() function
     """
+    # Create a local cache for this specific namespace
+    cache = {}
+    
     def tag(text):
-        return str(etree.QName(namespace, text))
+        cached = cache.get(text)
+        if cached is not None:
+            return cached
+        result = '{%s}%s' % (namespace, text)
+        cache[text] = result
+        return result
+    
     return tag
 
 

--- a/collada/common.py
+++ b/collada/common.py
@@ -1,11 +1,11 @@
+from functools import cache
+
 from collada.xmlutil import ElementMaker, COLLADA_NS
 
 E = ElementMaker(namespace=COLLADA_NS, nsmap={None: COLLADA_NS})
 
-# Cache for tag strings - key is (namespace, text), value is the qualified tag string
-_tag_cache = {}
 
-
+@cache
 def tag(text, namespace=None):
     """
     Tag a text key with the collada namespace, by default:
@@ -19,15 +19,7 @@ def tag(text, namespace=None):
     """
     if namespace is None:
         namespace = COLLADA_NS
-
-    cache_key = (namespace, text)
-    cached = _tag_cache.get(cache_key)
-    if cached is not None:
-        return cached
-
-    result = '{%s}%s' % (namespace, text)
-    _tag_cache[cache_key] = result
-    return result
+    return '{%s}%s' % (namespace, text)
 
 
 def tagger(namespace=None):
@@ -41,16 +33,9 @@ def tagger(namespace=None):
     :return:
       tag() function
     """
-    # Create a local cache for this specific namespace
-    cache = {}
-
+    @cache
     def tag(text):
-        cached = cache.get(text)
-        if cached is not None:
-            return cached
-        result = '{%s}%s' % (namespace, text)
-        cache[text] = result
-        return result
+        return '{%s}%s' % (namespace, text)
 
     return tag
 

--- a/collada/common.py
+++ b/collada/common.py
@@ -1,4 +1,4 @@
-from collada.xmlutil import etree, ElementMaker, COLLADA_NS
+from collada.xmlutil import ElementMaker, COLLADA_NS
 
 E = ElementMaker(namespace=COLLADA_NS, nsmap={None: COLLADA_NS})
 
@@ -19,12 +19,12 @@ def tag(text, namespace=None):
     """
     if namespace is None:
         namespace = COLLADA_NS
-    
+
     cache_key = (namespace, text)
     cached = _tag_cache.get(cache_key)
     if cached is not None:
         return cached
-    
+
     result = '{%s}%s' % (namespace, text)
     _tag_cache[cache_key] = result
     return result
@@ -43,7 +43,7 @@ def tagger(namespace=None):
     """
     # Create a local cache for this specific namespace
     cache = {}
-    
+
     def tag(text):
         cached = cache.get(text)
         if cached is not None:
@@ -51,7 +51,7 @@ def tagger(namespace=None):
         result = '{%s}%s' % (namespace, text)
         cache[text] = result
         return result
-    
+
     return tag
 
 

--- a/collada/geometry.py
+++ b/collada/geometry.py
@@ -171,35 +171,18 @@ class Geometry(DaeObject):
         id = node.get("id") or ""
         name = node.get("name") or ""
 
-        # Use pre-cached tags for efficiency
-        tags = getattr(collada, '_tags', None)
-        if tags:
-            tag_mesh = tags['mesh']
-            tag_source = tags['source']
-            tag_vertices = tags['vertices']
-            tag_input = tags['input']
-            tag_extra = tags['extra']
-            tag_double_sided = tags['double_sided']
-            tag_polylist = tags['polylist']
-            tag_triangles = tags['triangles']
-            tag_lines = tags['lines']
-            tag_polygons = tags['polygons']
-            # These aren't in pre-cache, compute once
-            tag_tristrips = collada.tag('tristrips')
-            tag_trifans = collada.tag('trifans')
-        else:
-            tag_mesh = collada.tag('mesh')
-            tag_source = collada.tag('source')
-            tag_vertices = collada.tag('vertices')
-            tag_input = collada.tag('input')
-            tag_extra = collada.tag('extra')
-            tag_double_sided = collada.tag('double_sided')
-            tag_polylist = collada.tag('polylist')
-            tag_triangles = collada.tag('triangles')
-            tag_tristrips = collada.tag('tristrips')
-            tag_trifans = collada.tag('trifans')
-            tag_lines = collada.tag('lines')
-            tag_polygons = collada.tag('polygons')
+        tag_mesh = collada.tag('mesh')
+        tag_source = collada.tag('source')
+        tag_vertices = collada.tag('vertices')
+        tag_input = collada.tag('input')
+        tag_extra = collada.tag('extra')
+        tag_double_sided = collada.tag('double_sided')
+        tag_polylist = collada.tag('polylist')
+        tag_triangles = collada.tag('triangles')
+        tag_tristrips = collada.tag('tristrips')
+        tag_trifans = collada.tag('trifans')
+        tag_lines = collada.tag('lines')
+        tag_polygons = collada.tag('polygons')
 
         meshnode = node.find(tag_mesh)
         if meshnode is None:

--- a/collada/geometry.py
+++ b/collada/geometry.py
@@ -170,7 +170,7 @@ class Geometry(DaeObject):
     def load(collada, localscope, node):
         id = node.get("id") or ""
         name = node.get("name") or ""
-        
+
         # Use pre-cached tags for efficiency
         tags = getattr(collada, '_tags', None)
         if tags:
@@ -200,7 +200,7 @@ class Geometry(DaeObject):
             tag_trifans = collada.tag('trifans')
             tag_lines = collada.tag('lines')
             tag_polygons = collada.tag('polygons')
-        
+
         meshnode = node.find(tag_mesh)
         if meshnode is None:
             raise DaeUnsupportedError('Unknown geometry node')
@@ -239,7 +239,7 @@ class Geometry(DaeObject):
 
         _primitives = []
         tri_tags = (tag_triangles, tag_tristrips, tag_trifans)
-        
+
         for subnode in meshnode:
             if subnode.tag == tag_polylist:
                 _primitives.append(polylist.Polylist.load(collada, sourcebyid, subnode))

--- a/collada/lineset.py
+++ b/collada/lineset.py
@@ -162,11 +162,18 @@ class LineSet(primitive.Primitive):
 
     @staticmethod
     def load(collada, localscope, node):
-        indexnode = node.find(collada.tag('p'))
+        # Use pre-cached tags for efficiency
+        tags = getattr(collada, '_tags', None)
+        if tags:
+            indexnode = node.find(tags['p'])
+            input_tag = tags['input']
+        else:
+            indexnode = node.find(collada.tag('p'))
+            input_tag = collada.tag('input')
         if indexnode is None:
             raise DaeIncompleteError('Missing index in line set')
 
-        source_array = primitive.Primitive._getInputs(collada, localscope, node.findall(collada.tag('input')))
+        source_array = primitive.Primitive._getInputs(collada, localscope, node.findall(input_tag))
 
         try:
             if indexnode.text is None or indexnode.text.isspace():

--- a/collada/lineset.py
+++ b/collada/lineset.py
@@ -162,14 +162,8 @@ class LineSet(primitive.Primitive):
 
     @staticmethod
     def load(collada, localscope, node):
-        # Use pre-cached tags for efficiency
-        tags = getattr(collada, '_tags', None)
-        if tags:
-            indexnode = node.find(tags['p'])
-            input_tag = tags['input']
-        else:
-            indexnode = node.find(collada.tag('p'))
-            input_tag = collada.tag('input')
+        indexnode = node.find(collada.tag('p'))
+        input_tag = collada.tag('input')
         if indexnode is None:
             raise DaeIncompleteError('Missing index in line set')
 

--- a/collada/polylist.py
+++ b/collada/polylist.py
@@ -263,10 +263,18 @@ class Polylist(primitive.Primitive):
 
     @staticmethod
     def load(collada, localscope, node):
-        indexnode = node.find(collada.tag('p'))
+        # Use pre-cached tags for efficiency
+        tags = getattr(collada, '_tags', None)
+        if tags:
+            indexnode = node.find(tags['p'])
+            vcountnode = node.find(tags['vcount'])
+            input_tag = tags['input']
+        else:
+            indexnode = node.find(collada.tag('p'))
+            vcountnode = node.find(collada.tag('vcount'))
+            input_tag = collada.tag('input')
         if indexnode is None:
             raise DaeIncompleteError('Missing index in polylist')
-        vcountnode = node.find(collada.tag('vcount'))
         if vcountnode is None:
             raise DaeIncompleteError('Missing vcount in polylist')
 
@@ -282,7 +290,7 @@ class Polylist(primitive.Primitive):
         except ValueError:
             raise DaeMalformedError('Corrupted vcounts in polylist')
 
-        all_inputs = primitive.Primitive._getInputs(collada, localscope, node.findall(collada.tag('input')))
+        all_inputs = primitive.Primitive._getInputs(collada, localscope, node.findall(input_tag))
 
         try:
             if indexnode.text is None or indexnode.text.isspace():

--- a/collada/polylist.py
+++ b/collada/polylist.py
@@ -263,16 +263,9 @@ class Polylist(primitive.Primitive):
 
     @staticmethod
     def load(collada, localscope, node):
-        # Use pre-cached tags for efficiency
-        tags = getattr(collada, '_tags', None)
-        if tags:
-            indexnode = node.find(tags['p'])
-            vcountnode = node.find(tags['vcount'])
-            input_tag = tags['input']
-        else:
-            indexnode = node.find(collada.tag('p'))
-            vcountnode = node.find(collada.tag('vcount'))
-            input_tag = collada.tag('input')
+        indexnode = node.find(collada.tag('p'))
+        vcountnode = node.find(collada.tag('vcount'))
+        input_tag = collada.tag('input')
         if indexnode is None:
             raise DaeIncompleteError('Missing index in polylist')
         if vcountnode is None:

--- a/collada/primitive.py
+++ b/collada/primitive.py
@@ -71,8 +71,9 @@ class Primitive(DaeObject):
         """
 
     # Known semantic types for fast lookup
-    _KNOWN_SEMANTICS = frozenset(['VERTEX', 'NORMAL', 'TEXCOORD', 'TEXTANGENT', 
-                                   'TEXBINORMAL', 'COLOR', 'TANGENT', 'BINORMAL'])
+    _KNOWN_SEMANTICS = frozenset([
+        'VERTEX', 'NORMAL', 'TEXCOORD', 'TEXTANGENT',
+        'TEXBINORMAL', 'COLOR', 'TANGENT', 'BINORMAL'])
 
     @staticmethod
     def _getInputsFromList(collada, localscope, inputs):
@@ -91,7 +92,7 @@ class Primitive(DaeObject):
                         to_append.append([offset, inputsemantic, '#' + inputsource.id, set])
             elif not isinstance(vertex_source, dict):
                 new_inputs.append(input)
-        
+
         # Combine with dereferenced dicts
         new_inputs.extend(to_append)
 

--- a/collada/primitive.py
+++ b/collada/primitive.py
@@ -70,80 +70,52 @@ class Primitive(DaeObject):
 
         """
 
+    # Known semantic types for fast lookup
+    _KNOWN_SEMANTICS = frozenset(['VERTEX', 'NORMAL', 'TEXCOORD', 'TEXTANGENT', 
+                                   'TEXBINORMAL', 'COLOR', 'TANGENT', 'BINORMAL'])
+
     @staticmethod
     def _getInputsFromList(collada, localscope, inputs):
         # first let's save any of the source that are references to a dict
         to_append = []
+        new_inputs = []
         for input in inputs:
             offset, semantic, source, set = input
-            if semantic == 'VERTEX':
-                vertex_source = localscope.get(source[1:])
-                if isinstance(vertex_source, dict):
-                    for inputsemantic, inputsource in vertex_source.items():
-                        if inputsemantic == 'POSITION':
-                            to_append.append([offset, 'VERTEX', '#' + inputsource.id, set])
-                        else:
-                            to_append.append([offset, inputsemantic, '#' + inputsource.id, set])
+            source_key = source[1:]
+            vertex_source = localscope.get(source_key)
+            if semantic == 'VERTEX' and isinstance(vertex_source, dict):
+                for inputsemantic, inputsource in vertex_source.items():
+                    if inputsemantic == 'POSITION':
+                        to_append.append([offset, 'VERTEX', '#' + inputsource.id, set])
+                    else:
+                        to_append.append([offset, inputsemantic, '#' + inputsource.id, set])
+            elif not isinstance(vertex_source, dict):
+                new_inputs.append(input)
+        
+        # Combine with dereferenced dicts
+        new_inputs.extend(to_append)
 
-        # remove all the dicts
-        inputs[:] = [input for input in inputs
-                     if not isinstance(localscope.get(input[2][1:]), dict)]
+        # Initialize all_inputs with empty lists for known semantics
+        all_inputs = {sem: [] for sem in Primitive._KNOWN_SEMANTICS}
 
-        # append the dereferenced dicts
-        for a in to_append:
-            inputs.append(a)
-
-        vertex_inputs = []
-        normal_inputs = []
-        texcoord_inputs = []
-        textangent_inputs = []
-        texbinormal_inputs = []
-        color_inputs = []
-        tangent_inputs = []
-        binormal_inputs = []
-
-        all_inputs = {}
-
-        for input in inputs:
+        for input in new_inputs:
             offset, semantic, source, set = input
             if len(source) < 2 or source[0] != '#':
                 raise DaeMalformedError('Incorrect source id "%s" in input' % source)
-            if source[1:] not in localscope:
+            source_key = source[1:]
+            if source_key not in localscope:
                 raise DaeBrokenRefError('Source input id "%s" not found' % source)
-            input = (input[0], input[1], input[2], input[3], localscope[source[1:]])
-            if semantic == 'VERTEX':
-                vertex_inputs.append(input)
-            elif semantic == 'NORMAL':
-                normal_inputs.append(input)
-            elif semantic == 'TEXCOORD':
-                texcoord_inputs.append(input)
-            elif semantic == 'TEXTANGENT':
-                textangent_inputs.append(input)
-            elif semantic == 'TEXBINORMAL':
-                texbinormal_inputs.append(input)
-            elif semantic == 'COLOR':
-                color_inputs.append(input)
-            elif semantic == 'TANGENT':
-                tangent_inputs.append(input)
-            elif semantic == 'BINORMAL':
-                binormal_inputs.append(input)
+            input_tuple = (offset, semantic, source, set, localscope[source_key])
+            if semantic in Primitive._KNOWN_SEMANTICS:
+                all_inputs[semantic].append(input_tuple)
             else:
                 try:
                     raise DaeUnsupportedError('Unknown input semantic: %s' % semantic)
                 except DaeUnsupportedError as ex:
                     collada.handleError(ex)
-                unknown_input = all_inputs.get(semantic, [])
-                unknown_input.append(input)
-                all_inputs[semantic] = unknown_input
-
-        all_inputs['VERTEX'] = vertex_inputs
-        all_inputs['NORMAL'] = normal_inputs
-        all_inputs['TEXCOORD'] = texcoord_inputs
-        all_inputs['TEXBINORMAL'] = texbinormal_inputs
-        all_inputs['TEXTANGENT'] = textangent_inputs
-        all_inputs['COLOR'] = color_inputs
-        all_inputs['TANGENT'] = tangent_inputs
-        all_inputs['BINORMAL'] = binormal_inputs
+                if semantic not in all_inputs:
+                    all_inputs[semantic] = []
+                all_inputs[semantic].append(input_tuple)
 
         return all_inputs
 

--- a/collada/scene.py
+++ b/collada/scene.py
@@ -367,7 +367,7 @@ class Node(SceneNode):
             self.transforms = transforms
         """A list of transformations effecting the node. This can
           contain any object that inherits from :class:`collada.scene.Transform`"""
-        
+
         # Use cached identity matrix when no transforms, otherwise compute the combined matrix
         if len(self.transforms) == 0:
             self.matrix = _IDENTITY_MATRIX
@@ -922,7 +922,7 @@ def loadNode(collada, node, localscope):
             tag_func('asset'): ('none', None),
         }
         collada._node_dispatch = dispatch
-    
+
     entry = dispatch.get(node.tag)
     if entry is not None:
         load_type, loader_class = entry

--- a/collada/scene.py
+++ b/collada/scene.py
@@ -573,10 +573,7 @@ class GeometryNode(SceneNode):
         geometry = collada.geometries.get(url[1:])
         if not geometry:
             raise DaeBrokenRefError('Geometry %s not found in library' % url)
-        # Use pre-cached XPath for materials
-        mat_xpath = getattr(collada, '_xpath_materials', None)
-        if mat_xpath is None:
-            mat_xpath = '%s/%s/%s' % (collada.tag('bind_material'), collada.tag('technique_common'), collada.tag('instance_material'))
+        mat_xpath = '%s/%s/%s' % (collada.tag('bind_material'), collada.tag('technique_common'), collada.tag('instance_material'))
         matnodes = node.findall(mat_xpath)
         materials = []
         for matnode in matnodes:
@@ -669,10 +666,7 @@ class ControllerNode(SceneNode):
         controller = collada.controllers.get(url[1:])
         if not controller:
             raise DaeBrokenRefError('Controller %s not found in library' % url)
-        # Use pre-cached XPath for materials
-        mat_xpath = getattr(collada, '_xpath_materials', None)
-        if mat_xpath is None:
-            mat_xpath = '%s/%s/%s' % (collada.tag('bind_material'), collada.tag('technique_common'), collada.tag('instance_material'))
+        mat_xpath = '%s/%s/%s' % (collada.tag('bind_material'), collada.tag('technique_common'), collada.tag('instance_material'))
         matnodes = node.findall(mat_xpath)
         materials = []
         for matnode in matnodes:

--- a/collada/source.py
+++ b/collada/source.py
@@ -84,29 +84,15 @@ class Source(DaeObject):
     @staticmethod
     def load(collada, localscope, node):
         sourceid = node.get('id')
-        # Use pre-cached tags for efficiency
-        tags = getattr(collada, '_tags', None)
-        if tags:
-            arraynode = node.find(tags['float_array'])
-            if arraynode is not None:
-                return FloatSource.load(collada, localscope, node)
-            arraynode = node.find(tags['IDREF_array'])
-            if arraynode is not None:
-                return IDRefSource.load(collada, localscope, node)
-            arraynode = node.find(tags['Name_array'])
-            if arraynode is not None:
-                return NameSource.load(collada, localscope, node)
-        else:
-            # Fallback for when tags aren't pre-cached
-            arraynode = node.find(collada.tag('float_array'))
-            if arraynode is not None:
-                return FloatSource.load(collada, localscope, node)
-            arraynode = node.find(collada.tag('IDREF_array'))
-            if arraynode is not None:
-                return IDRefSource.load(collada, localscope, node)
-            arraynode = node.find(collada.tag('Name_array'))
-            if arraynode is not None:
-                return NameSource.load(collada, localscope, node)
+        arraynode = node.find(collada.tag('float_array'))
+        if arraynode is not None:
+            return FloatSource.load(collada, localscope, node)
+        arraynode = node.find(collada.tag('IDREF_array'))
+        if arraynode is not None:
+            return IDRefSource.load(collada, localscope, node)
+        arraynode = node.find(collada.tag('Name_array'))
+        if arraynode is not None:
+            return NameSource.load(collada, localscope, node)
 
         if arraynode is None:
             raise DaeIncompleteError('No array found in source %s' % sourceid)
@@ -203,12 +189,7 @@ class FloatSource(Source):
     @staticmethod
     def load(collada, localscope, node):
         sourceid = node.get('id')
-        # Use pre-cached tags for efficiency
-        tags = getattr(collada, '_tags', None)
-        if tags:
-            arraynode = node.find(tags['float_array'])
-        else:
-            arraynode = node.find(collada.tag('float_array'))
+        arraynode = node.find(collada.tag('float_array'))
         if arraynode is None:
             raise DaeIncompleteError('No float_array in source node')
         if arraynode.text is None or arraynode.text.isspace():
@@ -221,10 +202,7 @@ class FloatSource(Source):
         # Replace NaN values with 0
         data[numpy.isnan(data)] = 0
 
-        # Use pre-cached XPath for accessor params
-        accessor_path = getattr(collada, '_xpath_accessor_params', None)
-        if accessor_path is None:
-            accessor_path = '%s/%s/%s' % (collada.tag('technique_common'), collada.tag('accessor'), collada.tag('param'))
+        accessor_path = '%s/%s/%s' % (collada.tag('technique_common'), collada.tag('accessor'), collada.tag('param'))
         paramnodes = node.findall(accessor_path)
         if not paramnodes:
             raise DaeIncompleteError('No accessor info in source node')

--- a/collada/source.py
+++ b/collada/source.py
@@ -84,17 +84,29 @@ class Source(DaeObject):
     @staticmethod
     def load(collada, localscope, node):
         sourceid = node.get('id')
-        arraynode = node.find(collada.tag('float_array'))
-        if arraynode is not None:
-            return FloatSource.load(collada, localscope, node)
-
-        arraynode = node.find(collada.tag('IDREF_array'))
-        if arraynode is not None:
-            return IDRefSource.load(collada, localscope, node)
-
-        arraynode = node.find(collada.tag('Name_array'))
-        if arraynode is not None:
-            return NameSource.load(collada, localscope, node)
+        # Use pre-cached tags for efficiency
+        tags = getattr(collada, '_tags', None)
+        if tags:
+            arraynode = node.find(tags['float_array'])
+            if arraynode is not None:
+                return FloatSource.load(collada, localscope, node)
+            arraynode = node.find(tags['IDREF_array'])
+            if arraynode is not None:
+                return IDRefSource.load(collada, localscope, node)
+            arraynode = node.find(tags['Name_array'])
+            if arraynode is not None:
+                return NameSource.load(collada, localscope, node)
+        else:
+            # Fallback for when tags aren't pre-cached
+            arraynode = node.find(collada.tag('float_array'))
+            if arraynode is not None:
+                return FloatSource.load(collada, localscope, node)
+            arraynode = node.find(collada.tag('IDREF_array'))
+            if arraynode is not None:
+                return IDRefSource.load(collada, localscope, node)
+            arraynode = node.find(collada.tag('Name_array'))
+            if arraynode is not None:
+                return NameSource.load(collada, localscope, node)
 
         if arraynode is None:
             raise DaeIncompleteError('No array found in source %s' % sourceid)
@@ -191,7 +203,12 @@ class FloatSource(Source):
     @staticmethod
     def load(collada, localscope, node):
         sourceid = node.get('id')
-        arraynode = node.find(collada.tag('float_array'))
+        # Use pre-cached tags for efficiency
+        tags = getattr(collada, '_tags', None)
+        if tags:
+            arraynode = node.find(tags['float_array'])
+        else:
+            arraynode = node.find(collada.tag('float_array'))
         if arraynode is None:
             raise DaeIncompleteError('No float_array in source node')
         if arraynode.text is None or arraynode.text.isspace():
@@ -201,9 +218,14 @@ class FloatSource(Source):
                 data = numpy.fromstring(arraynode.text, dtype=numpy.float32, sep=' ')
             except ValueError:
                 raise DaeMalformedError('Corrupted float array')
+        # Replace NaN values with 0
         data[numpy.isnan(data)] = 0
 
-        paramnodes = node.findall('%s/%s/%s' % (collada.tag('technique_common'), collada.tag('accessor'), collada.tag('param')))
+        # Use pre-cached XPath for accessor params
+        accessor_path = getattr(collada, '_xpath_accessor_params', None)
+        if accessor_path is None:
+            accessor_path = '%s/%s/%s' % (collada.tag('technique_common'), collada.tag('accessor'), collada.tag('param'))
+        paramnodes = node.findall(accessor_path)
         if not paramnodes:
             raise DaeIncompleteError('No accessor info in source node')
         components = [param.get('name') for param in paramnodes]

--- a/collada/triangleset.py
+++ b/collada/triangleset.py
@@ -197,11 +197,18 @@ class TriangleSet(primitive.Primitive):
 
     @staticmethod
     def load(collada, localscope, node):
-        indexnodes = node.findall(collada.tag('p'))
+        # Use pre-cached tags for efficiency
+        tags = getattr(collada, '_tags', None)
+        if tags:
+            indexnodes = node.findall(tags['p'])
+            input_tag = tags['input']
+        else:
+            indexnodes = node.findall(collada.tag('p'))
+            input_tag = collada.tag('input')
         if not indexnodes:
             raise DaeIncompleteError('Missing index in triangle set')
 
-        source_array = primitive.Primitive._getInputs(collada, localscope, node.findall(collada.tag('input')))
+        source_array = primitive.Primitive._getInputs(collada, localscope, node.findall(input_tag))
 
         def parse_p(indexnode):
             if indexnode.text is None or indexnode.text.isspace():

--- a/collada/triangleset.py
+++ b/collada/triangleset.py
@@ -197,14 +197,8 @@ class TriangleSet(primitive.Primitive):
 
     @staticmethod
     def load(collada, localscope, node):
-        # Use pre-cached tags for efficiency
-        tags = getattr(collada, '_tags', None)
-        if tags:
-            indexnodes = node.findall(tags['p'])
-            input_tag = tags['input']
-        else:
-            indexnodes = node.findall(collada.tag('p'))
-            input_tag = collada.tag('input')
+        indexnodes = node.findall(collada.tag('p'))
+        input_tag = collada.tag('input')
         if not indexnodes:
             raise DaeIncompleteError('Missing index in triangle set')
 

--- a/examples/benchmark_dae_load.py
+++ b/examples/benchmark_dae_load.py
@@ -4,7 +4,7 @@ Benchmark pycollada DAE loading performance.
 
 Usage:
     python examples/benchmark_dae_load.py <dae_file> [--runs N]
-    
+
 Examples:
     python examples/benchmark_dae_load.py myfile.dae
     python examples/benchmark_dae_load.py myfile.dae --runs 20
@@ -18,19 +18,19 @@ import collada
 
 def benchmark_load(dae_path: str, num_runs: int = 10):
     """Benchmark DAE loading and print timing results."""
-    
+
     path = Path(dae_path)
     if not path.exists():
         print(f"Error: File not found: {dae_path}")
         return
-    
+
     file_size_mb = path.stat().st_size / (1024 * 1024)
-    
+
     print(f"File: {path.name}")
     print(f"Size: {file_size_mb:.2f} MB")
     print(f"Runs: {num_runs}")
     print("-" * 40)
-    
+
     # Warm-up run and get DAE info
     dae = collada.Collada(dae_path)
     n_geom = len(dae.geometries) if hasattr(dae, 'geometries') else 0
@@ -40,7 +40,7 @@ def benchmark_load(dae_path: str, num_runs: int = 10):
     print(f"Cameras: {n_cam}")
     print(f"Materials: {n_mat}")
     print("-" * 40)
-    
+
     # Benchmark runs
     times = []
     for i in range(num_runs):
@@ -48,11 +48,11 @@ def benchmark_load(dae_path: str, num_runs: int = 10):
         collada.Collada(dae_path)
         end = time.perf_counter()
         times.append(end - start)
-    
+
     times.sort()
     mean_time = sum(times) / len(times)
     median_time = times[len(times) // 2]
-    
+
     print(f"Mean:   {mean_time * 1000:.1f} ms")
     print(f"Median: {median_time * 1000:.1f} ms")
     print(f"Min:    {min(times) * 1000:.1f} ms")
@@ -66,11 +66,10 @@ def main():
     parser.add_argument("dae_file", help="Path to DAE file to benchmark")
     parser.add_argument("--runs", "-n", type=int, default=10,
                         help="Number of benchmark runs (default: 10)")
-    
+
     args = parser.parse_args()
     benchmark_load(args.dae_file, num_runs=args.runs)
 
 
 if __name__ == "__main__":
     main()
-

--- a/examples/benchmark_dae_load.py
+++ b/examples/benchmark_dae_load.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Benchmark pycollada DAE loading performance.
+
+Usage:
+    python examples/benchmark_dae_load.py <dae_file> [--runs N]
+    
+Examples:
+    python examples/benchmark_dae_load.py myfile.dae
+    python examples/benchmark_dae_load.py myfile.dae --runs 20
+"""
+
+import argparse
+import time
+from pathlib import Path
+import collada
+
+
+def benchmark_load(dae_path: str, num_runs: int = 10):
+    """Benchmark DAE loading and print timing results."""
+    
+    path = Path(dae_path)
+    if not path.exists():
+        print(f"Error: File not found: {dae_path}")
+        return
+    
+    file_size_mb = path.stat().st_size / (1024 * 1024)
+    
+    print(f"File: {path.name}")
+    print(f"Size: {file_size_mb:.2f} MB")
+    print(f"Runs: {num_runs}")
+    print("-" * 40)
+    
+    # Warm-up run and get DAE info
+    dae = collada.Collada(dae_path)
+    n_geom = len(dae.geometries) if hasattr(dae, 'geometries') else 0
+    n_cam = len(dae.cameras) if hasattr(dae, 'cameras') else 0
+    n_mat = len(dae.materials) if hasattr(dae, 'materials') else 0
+    print(f"Geometries: {n_geom}")
+    print(f"Cameras: {n_cam}")
+    print(f"Materials: {n_mat}")
+    print("-" * 40)
+    
+    # Benchmark runs
+    times = []
+    for i in range(num_runs):
+        start = time.perf_counter()
+        collada.Collada(dae_path)
+        end = time.perf_counter()
+        times.append(end - start)
+    
+    times.sort()
+    mean_time = sum(times) / len(times)
+    median_time = times[len(times) // 2]
+    
+    print(f"Mean:   {mean_time * 1000:.1f} ms")
+    print(f"Median: {median_time * 1000:.1f} ms")
+    print(f"Min:    {min(times) * 1000:.1f} ms")
+    print(f"Max:    {max(times) * 1000:.1f} ms")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Benchmark pycollada DAE loading",
+    )
+    parser.add_argument("dae_file", help="Path to DAE file to benchmark")
+    parser.add_argument("--runs", "-n", type=int, default=10,
+                        help="Number of benchmark runs (default: 10)")
+    
+    args = parser.parse_args()
+    benchmark_load(args.dae_file, num_runs=args.runs)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
This PR improves DAE file loading performance by caching frequently used XML tag strings and reducing redundant object allocations.

The `tag()` function in `common.py` is called over 100k times when loading a DAE file of size ~1Mb. Each call previously created a new `QName` object. Now results are cached, eliminating this overhead.

Additionally, identity matrices in scene node loading are now shared when possible instead of being recreated for each node.

**Benchmark** (3.84 MB Porsche model, 299 geometries):

To test loading time:

```bash
cd examples/daeview/data && unzip Porsche-911-GT2.zip  && cd ../../..
python examples/benchmark_dae_load.py   examples/daeview/data/models/2008\ Porsche\ 911\ GT2\ \(997\)\(2\).dae 
```

| Version | Mean Load Time |
|---------|----------------|
| Before  | 160.7 ms       |
| After   | 130.7 ms       |

All existing tests pass.


