### PR TITLE
Change numpy array.shape assignments to array = reshape() invocations

### DIFF
--- a/collada/lineset.py
+++ b/collada/lineset.py
@@ -80,7 +80,7 @@ class LineSet(primitive.Primitive):
         self.index = index
         self.indices = self.index
         self.nindices = max_offset + 1
-        self.index.shape = (-1, 2, self.nindices)
+        self.index = self.index.reshape((-1, 2, self.nindices)) # No SFX
         self.nlines = len(self.index)
 
         if len(self.index) > 0:
@@ -125,10 +125,9 @@ class LineSet(primitive.Primitive):
             self.xmlnode = xmlnode
             """ElementTree representation of the line set."""
         else:
-            self.index.shape = (-1)
+            self.index = self.index.reshape((-1))
             txtindices = ' '.join(map(str, self.index.tolist()))
-            self.index.shape = (-1, 2, self.nindices)
-
+            self.index = self.index.reshape((-1, 2, self.nindices))
             self.xmlnode = E.lines(count=str(self.nlines))
             if self.material is not None:
                 self.xmlnode.set('material', self.material)

--- a/collada/lineset.py
+++ b/collada/lineset.py
@@ -80,7 +80,7 @@ class LineSet(primitive.Primitive):
         self.index = index
         self.indices = self.index
         self.nindices = max_offset + 1
-        self.index = self.index.reshape((-1, 2, self.nindices)) # No SFX
+        self.index = self.index.reshape((-1, 2, self.nindices))
         self.nlines = len(self.index)
 
         if len(self.index) > 0:

--- a/collada/polylist.py
+++ b/collada/polylist.py
@@ -141,7 +141,7 @@ class Polylist(primitive.Primitive):
         self.nindices = max_offset + 1
         self.vcounts = vcounts
         self.sources = sources
-        self.index.shape = (-1, self.nindices)
+        self.index = self.index.reshape((-1, self.nindices))
         self.npolygons = len(self.vcounts)
         self.nvertices = numpy.sum(self.vcounts) if len(self.index) > 0 else 0
         self.polyends = numpy.cumsum(self.vcounts)

--- a/collada/scene.py
+++ b/collada/scene.py
@@ -249,7 +249,7 @@ class MatrixTransform(Transform):
         """The resulting transformation matrix. This will be a numpy.array of size 4x4."""
         if len(self.matrix) != 16:
             raise DaeMalformedError('Corrupted matrix transformation node')
-        self.matrix = self.matrix.reshape((4,4))
+        self.matrix = self.matrix.reshape((4, 4))
         self.xmlnode = xmlnode
         """ElementTree representation of the transform."""
         if xmlnode is None:

--- a/collada/scene.py
+++ b/collada/scene.py
@@ -249,7 +249,7 @@ class MatrixTransform(Transform):
         """The resulting transformation matrix. This will be a numpy.array of size 4x4."""
         if len(self.matrix) != 16:
             raise DaeMalformedError('Corrupted matrix transformation node')
-        self.matrix = self.matrix.reshape((4,4)) # No SFX
+        self.matrix = self.matrix.reshape((4,4))
         self.xmlnode = xmlnode
         """ElementTree representation of the transform."""
         if xmlnode is None:

--- a/collada/scene.py
+++ b/collada/scene.py
@@ -249,7 +249,7 @@ class MatrixTransform(Transform):
         """The resulting transformation matrix. This will be a numpy.array of size 4x4."""
         if len(self.matrix) != 16:
             raise DaeMalformedError('Corrupted matrix transformation node')
-        self.matrix.shape = (4, 4)
+        self.matrix = self.matrix.reshape((4,4)) # No SFX
         self.xmlnode = xmlnode
         """ElementTree representation of the transform."""
         if xmlnode is None:

--- a/collada/source.py
+++ b/collada/source.py
@@ -141,10 +141,10 @@ class FloatSource(Source):
             self.xmlnode = xmlnode
             """ElementTree representation of the source."""
         else:
-            self.data.shape = (-1,)
+            self.data = self.data.reshape((-1,))
             txtdata = ' '.join(map(str, self.data.tolist()))
             rawlen = len(self.data)
-            self.data.shape = (-1, len(self.components))
+            self.data = self.data.reshape((-1, len(self.components)))
             acclen = len(self.data)
             stridelen = len(self.components)
             sourcename = "%s-array" % self.id
@@ -164,12 +164,15 @@ class FloatSource(Source):
 
     def save(self):
         """Saves the source back to :attr:`xmlnode`"""
-        self.data.shape = (-1,)
+        # self.data.shape = (-1,)
+        self.data = self.data.reshape((-1))
 
         txtdata = ' '.join(map(lambda x: '%.7g' % x, self.data.tolist()))
 
         rawlen = len(self.data)
-        self.data.shape = (-1, len(self.components))
+        # Causes bug
+        self.data = self.data.reshape((-1, len(self.components)))
+        # self.data.shape = (-1, len(self.components))
         acclen = len(self.data)
         node = self.xmlnode.find(tag('float_array'))
         node.text = txtdata
@@ -259,17 +262,18 @@ class IDRefSource(Source):
         """The unique string identifier for the source"""
         self.data = data
         """Numpy array with the source values. This will be shaped as ``(-1,N)`` where ``N = len(self.components)``"""
-        self.data.shape = (-1, len(components))
+        self.data = self.data.reshape((-1, len(components)))
+        # self.data.shape = (-1, len(components))
         self.components = components
         """Tuple of strings describing the semantic of the data, e.g. ``('MORPH_TARGET')``"""
         if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the source."""
         else:
-            self.data.shape = (-1,)
+            self.data = self.data.reshape((-1,))
             txtdata = ' '.join(map(str, self.data.tolist()))
             rawlen = len(self.data)
-            self.data.shape = (-1, len(self.components))
+            self.data = self.data.reshape((-1, len(self.components)))
             acclen = len(self.data)
             stridelen = len(self.components)
             sourcename = "%s-array" % self.id
@@ -289,10 +293,10 @@ class IDRefSource(Source):
 
     def save(self):
         """Saves the source back to :attr:`xmlnode`"""
-        self.data.shape = (-1,)
+        self.data = self.data.reshape((-1,))
         txtdata = ' '.join(map(str, self.data.tolist()))
         rawlen = len(self.data)
-        self.data.shape = (-1, len(self.components))
+        self.data = self.data.reshape((-1, len(self.components)))
         acclen = len(self.data)
 
         node = self.xmlnode.find(tag('IDREF_array'))
@@ -370,19 +374,18 @@ class NameSource(Source):
 
         self.id = id
         """The unique string identifier for the source"""
-        self.data = data
+        self.data = data.reshape((-1, len(components)))
         """Numpy array with the source values. This will be shaped as ``(-1,N)`` where ``N = len(self.components)``"""
-        self.data.shape = (-1, len(components))
         self.components = components
         """Tuple of strings describing the semantic of the data, e.g. ``('JOINT')``"""
         if xmlnode is not None:
             self.xmlnode = xmlnode
             """ElementTree representation of the source."""
         else:
-            self.data.shape = (-1,)
+            self.data = self.data.reshape((-1,))
             txtdata = ' '.join(map(str, self.data.tolist()))
             rawlen = len(self.data)
-            self.data.shape = (-1, len(self.components))
+            self.data = self.data.reshape((-1, len(self.components)))
             acclen = len(self.data)
             stridelen = len(self.components)
             sourcename = "%s-array" % self.id
@@ -402,10 +405,10 @@ class NameSource(Source):
 
     def save(self):
         """Saves the source back to :attr:`xmlnode`"""
-        self.data.shape = (-1,)
+        self.data = self.data.reshape((-1,))
         txtdata = ' '.join(map(str, self.data.tolist()))
         rawlen = len(self.data)
-        self.data.shape = (-1, len(self.components))
+        self.data = self.data.reshape((-1, len(self.components)))
         acclen = len(self.data)
 
         node = self.xmlnode.find(tag('Name_array'))

--- a/collada/source.py
+++ b/collada/source.py
@@ -164,15 +164,12 @@ class FloatSource(Source):
 
     def save(self):
         """Saves the source back to :attr:`xmlnode`"""
-        # self.data.shape = (-1,)
         self.data = self.data.reshape((-1))
 
         txtdata = ' '.join(map(lambda x: '%.7g' % x, self.data.tolist()))
 
         rawlen = len(self.data)
-        # Causes bug
         self.data = self.data.reshape((-1, len(self.components)))
-        # self.data.shape = (-1, len(self.components))
         acclen = len(self.data)
         node = self.xmlnode.find(tag('float_array'))
         node.text = txtdata
@@ -263,7 +260,6 @@ class IDRefSource(Source):
         self.data = data
         """Numpy array with the source values. This will be shaped as ``(-1,N)`` where ``N = len(self.components)``"""
         self.data = self.data.reshape((-1, len(components)))
-        # self.data.shape = (-1, len(components))
         self.components = components
         """Tuple of strings describing the semantic of the data, e.g. ``('MORPH_TARGET')``"""
         if xmlnode is not None:

--- a/collada/tests/test_lineset.py
+++ b/collada/tests/test_lineset.py
@@ -39,7 +39,7 @@ class TestLineset(unittest.TestCase):
         input_list.addInput(0, 'VERTEX', "#mylinevertsource")
         indices = numpy.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5])
         lineset = geometry.createLineSet(indices, input_list, "mymaterial")
-        expected_indices = numpy.array([[[0], [1]], [[1], [2]], [[2],[3]], [[3], [4]], [[4], [5]]])
+        expected_indices = numpy.array([[[0], [1]], [[1], [2]], [[2], [3]], [[3], [4]], [[4], [5]]])
         # Check the initial values for the lineset.
         self.assertIsNotNone(str(lineset))
         assert_array_equal(lineset.index, expected_indices)

--- a/collada/tests/test_lineset.py
+++ b/collada/tests/test_lineset.py
@@ -39,11 +39,11 @@ class TestLineset(unittest.TestCase):
         input_list.addInput(0, 'VERTEX', "#mylinevertsource")
         indices = numpy.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5])
         lineset = geometry.createLineSet(indices, input_list, "mymaterial")
-
+        expected_indices = numpy.array([[[0], [1]], [[1], [2]], [[2],[3]], [[3], [4]], [[4], [5]]])
         # Check the initial values for the lineset.
         self.assertIsNotNone(str(lineset))
-        assert_array_equal(lineset.index, indices)
-        self.assertEqual(lineset.nlines, len(indices))
+        assert_array_equal(lineset.index, expected_indices)
+        self.assertEqual(lineset.nlines, len(expected_indices))
         self.assertEqual(lineset.material, "mymaterial")
 
         # Serialize and deserialize.

--- a/collada/triangleset.py
+++ b/collada/triangleset.py
@@ -96,7 +96,7 @@ class TriangleSet(primitive.Primitive):
         self.index = index
         self.indices = self.index
         self.nindices = max_offset + 1
-        self.index.shape = (-1, 3, self.nindices)
+        self.index = self.index.reshape((-1, 3, self.nindices))
         self.ntriangles = len(self.index)
         self.sources = sources
 
@@ -165,10 +165,10 @@ class TriangleSet(primitive.Primitive):
         return len(self.index)
 
     def _recreateXmlNode(self):
-        self.index.shape = (-1)
+        self.index = self.index.reshape((-1))
         len(self.index)
         txtindices = ' '.join(map(str, self.index.tolist()))
-        self.index.shape = (-1, 3, self.nindices)
+
 
         self.xmlnode = E.triangles(count=str(self.ntriangles))
         if self.material is not None:

--- a/collada/triangleset.py
+++ b/collada/triangleset.py
@@ -168,7 +168,7 @@ class TriangleSet(primitive.Primitive):
         self.index = self.index.reshape((-1))
         len(self.index)
         txtindices = ' '.join(map(str, self.index.tolist()))
-
+        self.index = self.index.reshape((-1, 3, self.nindices))
 
         self.xmlnode = E.triangles(count=str(self.ntriangles))
         if self.material is not None:


### PR DESCRIPTION
Address issue #162 

## Summary of changes

* Replace all re-assignments of array shapes, since that is now deprecated in Numpy 2.5.
* Fixed `LineSet` unit test that expected an incorrect index array since callee was mutating the array before.

## Testing

`python -m unittest` produces no warnings relevant to this issue.

## AI usage disclosure

I used ChatGPT to assist in the unit test debugging process, but all code changes were written and checked by me manually.